### PR TITLE
Add Image Id and Hardware Id for a Cloud Template

### DIFF
--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
@@ -24,13 +24,11 @@
     <f:entry title="Public Key" field="publicKey">
         <f:textarea/>
     </f:entry>
-
     <f:entry title="Cloud Instance Templates" description="${%List of Cloud Instances to be launched as slaves}">
         <f:repeatable field="templates">
             <st:include page="config.jelly" class="${descriptor.clazz}"/>
         </f:repeatable>
     </f:entry>
-
 
     <f:validateButton title="${%Generate Key Pair}" progress="${%Generate...}" method="generateKeyPair"
                       with="identity,credential"/>

--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -5,6 +5,20 @@
         <f:textbox/>
     </f:entry>
 
+    <f:entry title="Hardware Id" field="hardwareId">
+        <f:textbox  />
+    </f:entry>
+
+    <f:validateButton title="${%Check Hardware Id}" progress="${%Checking...}" method="validateHardwareId"
+                      with="providerName,identity,credential,hardwareId"/>
+
+    <f:entry title="Image Id" field="imageId">
+       <f:textbox />
+    </f:entry>
+
+    <f:validateButton title="${%Check Image Id}" progress="${%Checking...}" method="validateImageId"
+                      with="providerName,identity,credential,imageId"/>
+
     <f:entry title="Description" field="description">
         <f:textarea/>
     </f:entry>
@@ -38,5 +52,6 @@
             <f:repeatableDeleteButton/>
         </div>
     </f:entry>
+
 </table>
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-osVersion.html
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-osVersion.html
@@ -1,3 +1,3 @@
 <div>
-  The OS Version to be used during provisioning.
+  The OS Version String (regex) to be used during provisioning.
 </div>

--- a/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -12,7 +12,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
 
    public void testConfigRoundtrip() throws Exception {
       String name = "testSlave";
-      JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, 1, 512, "osFamily",
+      JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", "hardwareId", 1, 512, "osFamily",
             "osVersion", "jclouds-slave-type1 jclouds-type2", "Description",
             "initScript");
 


### PR DESCRIPTION
- Add Image Id and Hardware Id configuration option 
  - If Image Id is valid and provided, then slave template will use image id instead of os version and os family configuration. If hardware id is provided then slave template will use the hardware id instead of ram and min cores.
  - Validation for Image Id and Hardware Id that will show a possible match as "Did you mean ****\* ? " along with toString representation of matched Image/HardwareProfile
- Other Stuff
  - Renamed CreateNodesInGroupWith.... to createNodeWithJDK
  - Added AutoComplete for OSFamilies
  - help file for osVersion
  - Updated tests
