### PR TITLE
Clean up whitespace in form fields

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -17,6 +17,7 @@ import hudson.slaves.Cloud;
 import hudson.slaves.NodeProvisioner;
 import hudson.util.FormValidation;
 import hudson.util.StreamTaskListener;
+import hudson.Util;
 import org.jclouds.Constants;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.ComputeServiceContext;
@@ -79,13 +80,13 @@ public class JCloudsCloud extends Cloud {
                        final String endPointUrl,
                        final List<JCloudsSlaveTemplate> templates) {
       super(profile);
-      this.profile = profile;
-      this.providerName = providerName;
-      this.identity = identity;
-      this.credential = credential;
+      this.profile = Util.fixEmptyAndTrim(profile);
+      this.providerName = Util.fixEmptyAndTrim(providerName);
+      this.identity = Util.fixEmptyAndTrim(identity);
+      this.credential = Util.fixEmptyAndTrim(credential);
       this.privateKey = privateKey;
       this.publicKey = publicKey;
-      this.endPointUrl = endPointUrl;
+      this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
       this.templates = Objects.firstNonNull(templates, Collections.<JCloudsSlaveTemplate>emptyList());
       setCloudForTemplates();
 
@@ -229,6 +230,12 @@ public class JCloudsCloud extends Cloud {
          if (privateKey == null)
             return FormValidation.error("Private key is not specified. Click 'Generate Key' to generate one.");
 
+
+         // Remove empty text/whitespace from the fields.
+         providerName = Util.fixEmptyAndTrim(providerName);
+         identity = Util.fixEmptyAndTrim(identity);
+         credential = Util.fixEmptyAndTrim(credential);
+         endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
 
          Iterable<Module> modules = ImmutableSet.<Module>of(new SshjSshClientModule(), new SLF4JLoggingModule(),
                new EnterpriseConfigurationModule());

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -72,17 +72,17 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate> {
                                final String description,
                                final String initScript) {
 
-      this.name = name;
-      this.imageId = imageId;
-      this.hardwareId = hardwareId;
-      this.cores = cores;
-      this.ram = ram;
-      this.osFamily = Util.fixNull(osFamily);
-      this.osVersion = Util.fixNull(osVersion);
-      this.labelString = Util.fixNull(labelString);
-      this.description = Util.fixNull(description);
-      this.initScript = Util.fixNull(initScript);
-      parseLabels();
+       this.name = Util.fixEmptyAndTrim(name);
+       this.imageId = Util.fixEmptyAndTrim(imageId);
+       this.hardwareId = Util.fixEmptyAndTrim(hardwareId);
+       this.cores = cores;
+       this.ram = ram;
+       this.osFamily = Util.fixNull(osFamily);
+       this.osVersion = Util.fixNull(osVersion);
+       this.labelString = Util.fixNull(labelString);
+       this.description = Util.fixNull(description);
+       this.initScript = Util.fixNull(initScript);
+       parseLabels();
    }
 
    public double getCores() {
@@ -271,6 +271,12 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate> {
             return FormValidation.error("Image Id shouldn't be empty");
          }
 
+         // Remove empty text/whitespace from the fields.
+         providerName = Util.fixEmptyAndTrim(providerName);
+         identity = Util.fixEmptyAndTrim(identity);
+         credential = Util.fixEmptyAndTrim(credential);
+         imageId = Util.fixEmptyAndTrim(imageId);
+
          FormValidation result = FormValidation.error("Invalid Image Id, please check the value and try again.");
          ComputeService computeService = null;
          try {
@@ -314,6 +320,12 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate> {
          if (Strings.isNullOrEmpty(hardwareId)) {
             return FormValidation.error("Hardware Id shouldn't be empty");
          }
+
+         // Remove empty text/whitespace from the fields.
+         providerName = Util.fixEmptyAndTrim(providerName);
+         identity = Util.fixEmptyAndTrim(identity);
+         credential = Util.fixEmptyAndTrim(credential);
+         hardwareId = Util.fixEmptyAndTrim(hardwareId);
 
          FormValidation result = FormValidation.error("Invalid Hardware Id, please check the value and try again.");
          ComputeService computeService = null;


### PR DESCRIPTION
I've found in my testing that when I cut and paste values into the identity/credentials/etc fields, there's often a trailing or leading space, which ends up borking things non-obviously. So hey, let's use fixEmptyAndTrim to get rid of those spaces!
