### PR TITLE
Connect slaves to clouds better

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -70,30 +70,29 @@ public class JCloudsCloud extends Cloud {
    public static JCloudsCloud get() {
       return Hudson.getInstance().clouds.get(JCloudsCloud.class);
    }
-
-   @DataBoundConstructor
-   public JCloudsCloud(final String profile,
-                       final String providerName,
-                       final String identity,
-                       final String credential,
-                       final String privateKey,
-                       final String publicKey,
-                       final String endPointUrl,
-                       final int instanceCap,
-                       final List<JCloudsSlaveTemplate> templates) {
-      super(profile);
-      this.profile = Util.fixEmptyAndTrim(profile);
-      this.providerName = Util.fixEmptyAndTrim(providerName);
-      this.identity = Util.fixEmptyAndTrim(identity);
-      this.credential = Util.fixEmptyAndTrim(credential);
-      this.privateKey = privateKey;
-      this.publicKey = publicKey;
-      this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
-      this.instanceCap = instanceCap;
-      this.templates = Objects.firstNonNull(templates, Collections.<JCloudsSlaveTemplate>emptyList());
-      setCloudForTemplates();
-
-   }
+    
+    @DataBoundConstructor
+    public JCloudsCloud(final String profile,
+                        final String providerName,
+                        final String identity,
+                        final String credential,
+                        final String privateKey,
+                        final String publicKey,
+                        final String endPointUrl,
+                        final int instanceCap,
+                        final List<JCloudsSlaveTemplate> templates) {
+        super(Util.fixEmptyAndTrim(profile));
+        this.profile = Util.fixEmptyAndTrim(profile);
+        this.providerName = Util.fixEmptyAndTrim(providerName);
+        this.identity = Util.fixEmptyAndTrim(identity);
+        this.credential = Util.fixEmptyAndTrim(credential);
+        this.privateKey = privateKey;
+        this.publicKey = publicKey;
+        this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
+        this.instanceCap = instanceCap;
+        this.templates = Objects.firstNonNull(templates, Collections.<JCloudsSlaveTemplate>emptyList());
+        setCloudForTemplates();
+    }
 
    protected Object setCloudForTemplates() {
       for (JCloudsSlaveTemplate template : templates)
@@ -174,7 +173,7 @@ public class JCloudsCloud extends Cloud {
       Collection<Node> jcloudsNodes = Collections2.filter(Jenkins.getInstance().getNodes(), new Predicate<Node>() {
          public boolean apply(@Nullable Node node) {
             //TODO Need to check if the node status should be taken into consideration for determining the instace cap
-            return node != null && JCloudsSlave.class.isInstance(node);
+             return node != null && JCloudsSlave.class.isInstance(node) && ((JCloudsSlave)node).getCloudName().equals(profile);
          }
       });
 

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
@@ -31,6 +31,10 @@ public class JCloudsComputer extends SlaveComputer {
       return (JCloudsSlave) super.getNode();
    }
 
+    public String getCloudName() {
+        return getNode().getCloudName();
+    }
+
    /**
     * Really deletes the slave, by terminating the instance.
     */

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
@@ -25,9 +25,11 @@ public class JCloudsSlave extends Slave {
     private static final Logger LOGGER = Logger.getLogger(JCloudsSlave.class.getName());
     private NodeMetadata nodeMetaData;
     public final boolean stopOnTerminate;
+    private String cloudName;
     
    @DataBoundConstructor
-   public JCloudsSlave(String name,
+   public JCloudsSlave(String cloudName,
+                       String name,
                        String nodeDescription,
                        String remoteFS,
                        String numExecutors,
@@ -39,34 +41,37 @@ public class JCloudsSlave extends Slave {
                        boolean stopOnTerminate) throws Descriptor.FormException, IOException {
       super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
       this.stopOnTerminate = stopOnTerminate;
+      this.cloudName = cloudName;
    }
 
-   /**
-    * Constructs a new slave from JCloud's NodeMetadata
-    *
-    * @param metadata - JCloudsNodeMetadata
-    * @param labelString - Label(s) for this slave.
-    * @param description - Description of this slave.
-    * @param numExecutors - Number of executors for this slave.
-    * @param stopOnTerminate - if true, suspend the slave rather than terminating it.
-    * @throws IOException
-    * @throws Descriptor.FormException
-    */
-    public JCloudsSlave(NodeMetadata metadata, final String labelString,
+    /**
+     * Constructs a new slave from JCloud's NodeMetadata
+     *
+     * @param cloudName - the name of the cloud that's provisioning this slave.
+     * @param metadata - JCloudsNodeMetadata
+     * @param labelString - Label(s) for this slave.
+     * @param description - Description of this slave.
+     * @param numExecutors - Number of executors for this slave.
+     * @param stopOnTerminate - if true, suspend the slave rather than terminating it.
+     * @throws IOException
+     * @throws Descriptor.FormException
+     */
+    public JCloudsSlave(final String cloudName, NodeMetadata metadata, final String labelString,
                         final String description, final String numExecutors,
                         final boolean stopOnTerminate) throws IOException, Descriptor.FormException {
-      this(metadata.getName(),
-           description,
-           "/jenkins",
-           numExecutors,
-           Mode.NORMAL,
-           labelString,
-           new JCloudsLauncher(),
-           new JCloudsRetentionStrategy(),
-           Collections.<NodeProperty<?>>emptyList(),
-           stopOnTerminate);
-      this.nodeMetaData = metadata;
-   }
+        this(cloudName,
+             metadata.getName(),
+             description,
+             "/jenkins",
+             numExecutors,
+             Mode.NORMAL,
+             labelString,
+             new JCloudsLauncher(),
+             new JCloudsRetentionStrategy(),
+             Collections.<NodeProperty<?>>emptyList(),
+             stopOnTerminate);
+        this.nodeMetaData = metadata;
+    }
 
    /**
     * Get Jclouds NodeMetadata associated with this Slave.
@@ -77,6 +82,15 @@ public class JCloudsSlave extends Slave {
       return nodeMetaData;
    }
 
+    /**
+     * Get the JClouds profile identifier for the Cloud associated with this slave.
+     *
+     * @return cloudName
+     */
+    public String getCloudName() {
+        return cloudName;
+    }
+    
    /**
     * {@inheritDoc}
     */

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -113,7 +113,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate> {
       LOGGER.info("Provisioning new node");
       NodeMetadata nodeMetadata = createNodeWithJdk();
       try {
-          return new JCloudsSlave(nodeMetadata, labelString, description, numExecutors, stopOnTerminate);
+          return new JCloudsSlave(getCloud().getDisplayName(), nodeMetadata, labelString, description, numExecutors, stopOnTerminate);
       } catch (Descriptor.FormException e) {
          throw new AssertionError("Invalid configuration " + e.getMessage());
       }


### PR DESCRIPTION
Add cloudName to slaves, so that we can backtrack from a Cloud to which Slaves are actually in it. Needed to get instanceCap to work properly with multiple clouds.
