### PR TITLE
Fix instance cap check, add autoprovisioning, improve retention strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The above command will start jenkins with JClouds plugin pre-configured.
   - Profile : the name of the profile e.g, aws-slave-profile
   - Provider Name: type first two characters and you'll get an auto-completed provider name (e.g. aws-ec2 or hpcloud-compute)
   - End Point URL: if your provider API needs an endpoint configuration, add it here, otherwise leave it empty.
+  - Max Number of Instances: The maximum number of instances to run from this cloud at one time.
+  - Retention Time: How long, in minutes, to wait for a slave to remain idle before disconnecting and terminating it. Defaults to 30.
   - Identity : your accessId
   - Credential: your secret key
   - RSA Private Key/Public Key: If you have a keypair, then just copy paste the public and private key parts, otherwise click on `Generate Key Pair` button.

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -70,6 +70,7 @@ public class JCloudsCloud extends Cloud {
    public final String publicKey;
    public final String endPointUrl;
    public final String profile;
+    private final int retentionTime;
    public int instanceCap;
    public final List<JCloudsSlaveTemplate> templates;
    private transient ComputeService compute;
@@ -87,6 +88,7 @@ public class JCloudsCloud extends Cloud {
                         final String publicKey,
                         final String endPointUrl,
                         final int instanceCap,
+                        final int retentionTime,
                         final List<JCloudsSlaveTemplate> templates) {
         super(Util.fixEmptyAndTrim(profile));
         this.profile = Util.fixEmptyAndTrim(profile);
@@ -97,6 +99,7 @@ public class JCloudsCloud extends Cloud {
         this.publicKey = publicKey;
         this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
         this.instanceCap = instanceCap;
+        this.retentionTime = retentionTime;
         this.templates = Objects.firstNonNull(templates, Collections.<JCloudsSlaveTemplate>emptyList());
         readResolve();
     }
@@ -108,6 +111,19 @@ public class JCloudsCloud extends Cloud {
       return this;
    }
 
+
+    /**
+     * Get the retention time, defaulting to 30 minutes.
+     */
+    public int getRetentionTime() {
+        if (retentionTime == 0) {
+            return 30;
+        } else {
+            return retentionTime;
+        }
+    }
+        
+    
    public ComputeService getCompute() {
       if (this.compute == null) {
          Properties overrides = new Properties();

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
@@ -35,18 +35,25 @@ public class JCloudsComputer extends SlaveComputer {
         return getNode().getCloudName();
     }
 
-   /**
-    * Really deletes the slave, by terminating the instance.
-    */
-   @Override
-   public HttpResponse doDoDelete() throws IOException {
-      LOGGER.info("Terminating " + getName() + " slave");
-      JCloudsSlave slave = getNode();
-      if (slave.getChannel() != null) {
-         slave.getChannel().close();
-      }
-      slave.terminate();
-      Hudson.getInstance().removeNode(slave);
-      return new HttpRedirect("..");
-   }
+    /**
+     * Really deletes the slave, by terminating the instance.
+     */
+    @Override
+    public HttpResponse doDoDelete() throws IOException {
+        deleteSlave();
+        return new HttpRedirect("..");
+    }
+    
+    /**
+     * Delete the slave, terminate the instance. Can be called eitehr by doDoDelete() or from JCloudsRetentionStrategy.
+     */
+    public void deleteSlave() throws IOException {
+        LOGGER.info("Terminating " + getName() + " slave");
+        JCloudsSlave slave = getNode();
+        if (slave.getChannel() != null) {
+            slave.getChannel().close();
+        }
+        slave.terminate();
+        Hudson.getInstance().removeNode(slave);
+    }
 }

--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
@@ -10,11 +10,15 @@
         <f:textbox/>
     </f:entry>
 
-    <f:entry title="Identity" field="identity">
+    <f:entry title="Max. No. of Instances" field="instanceCap">
         <f:textbox/>
     </f:entry>
 
-    <f:entry title="Max. No. of Instances" field="instanceCap">
+    <f:entry title="Retention Time" field="retentionTime">
+        <f:textbox/>
+    </f:entry>
+
+    <f:entry title="Identity" field="identity">
         <f:textbox/>
     </f:entry>
 

--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-retentionTime.html
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-retentionTime.html
@@ -1,0 +1,3 @@
+<div>
+  Number of minutes to wait for an idle slave to be used again before it's removed. Defaults to 30.
+</div>

--- a/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
@@ -32,6 +32,7 @@ public class JCloudsCloudTest extends HudsonTestCase {
       WebAssert.assertInputPresent(page2, "_.identity");
       WebAssert.assertInputPresent(page2, "_.credential");
       WebAssert.assertInputPresent(page2, "_.instanceCap");
+      WebAssert.assertInputPresent(page2, "_.retentionTime");
 
       HtmlForm configForm2 = page2.getFormByName("config");
       assertNotNull(configForm2.getTextAreaByName("_.privateKey"));
@@ -48,18 +49,18 @@ public class JCloudsCloudTest extends HudsonTestCase {
    public void testConfigRoundtrip() throws Exception {
 
       JCloudsCloud original = new JCloudsCloud("aws-profile", "aws-ec2", "identity", "credential", "privateKey", "publicKey",
-            "endPointUrl", 1 , Collections.<JCloudsSlaveTemplate>emptyList());
+                                               "endPointUrl", 1 , 30, Collections.<JCloudsSlaveTemplate>emptyList());
 
       hudson.clouds.add(original);
       submit(createWebClient().goTo("configure").getFormByName("config"));
 
       assertEqualBeans(original,
                        hudson.clouds.getByName("aws-profile"),
-                       "profile,providerName,identity,credential,privateKey,publicKey,endPointUrl,instanceCap");
+                       "profile,providerName,identity,credential,privateKey,publicKey,endPointUrl,instanceCap,retentionTime");
 
       assertEqualBeans(original,
                        JCloudsCloud.getByName("aws-profile"),
-                       "profile,providerName,identity,credential,privateKey,publicKey,endPointUrl,instanceCap");
+                       "profile,providerName,identity,credential,privateKey,publicKey,endPointUrl,instanceCap,retentionTime");
 }
 
 

--- a/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -20,7 +20,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
       templates.add(originalTemplate);
 
       JCloudsCloud originalCloud = new JCloudsCloud("aws-profile", "aws-ec2", "identity", "credential", "privateKey", "publicKey",
-            "endPointUrl", 1, templates);
+                                                    "endPointUrl", 1, 30, templates);
 
       hudson.clouds.add(originalCloud);
       submit(createWebClient().goTo("configure").getFormByName("config"));


### PR DESCRIPTION
- Fix instance cap check to compare against list of nodes from compute service.
- Add autoprovisioning.
- Add retention time to JCloudsCloud configuration.
