### PR TITLE
At smartos-ssh 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,12 @@
             <groupId>org.jclouds</groupId>
             <artifactId>jclouds-allcompute</artifactId>
             <version>${jclouds.version}</version>
-        </dependency>
+        </dependency>        
+        <dependency>
+            <groupId>org.jclouds.labs</groupId>
+            <artifactId>smartos-ssh</artifactId>
+            <version>${jclouds.version}</version>
+        </dependency>		
         <dependency>
             <groupId>org.jclouds</groupId>
             <artifactId>jclouds-allblobstore</artifactId>


### PR DESCRIPTION
When the next -beta or -release of jclouds happens, can you merge this? (As this will be the first non-SNAPSHOT release that contains it).

smartos-ssh support was built for jenkins slaves.
