### PR TITLE
Fix for JENKINS-15970: Add forcible synchronized serial delay option

### DIFF
--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -65,6 +65,11 @@
       <f:entry title="Override Retention Time" field="overrideRetentionTime">
         <f:textbox />
       </f:entry>
+      
+      <f:entry title="Delay before spooling up (ms)" field="spoolDelayMs">
+        <f:textbox />
+      </f:entry>
+      
       <f:entry title="Init Script" field="initScript">
         <f:textarea />
       </f:entry>

--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-spoolDelayMs.html
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/help-spoolDelayMs.html
@@ -1,0 +1,3 @@
+<div>
+  Optional delay before spooling up a VM instance (in milliseconds).
+</div>

--- a/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -14,7 +14,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
       String name = "testSlave";
       JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", "hardwareId", 1, 512, "osFamily",
                                                                        "osVersion", "jclouds-slave-type1 jclouds-type2", "Description",
-                                                                       "initScript", "1", false, null, null, true, "jenkins", false, null, false, 5);
+                                                                       "initScript", "1", false, null, null, true, "jenkins", false, null, false, 5, 0);
 
       List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
       templates.add(originalTemplate);


### PR DESCRIPTION
Adds a delay to avoid Jenkins sending a spool VM request that might exceed request limits (e.g. 2/sec max)
