### PR TITLE
[Fix JENKINS-16632] Don't print auth stack traces.

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStorePublisher.java
+++ b/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStorePublisher.java
@@ -161,7 +161,9 @@ public class BlobStorePublisher extends Recorder implements Describable<Publishe
          }
       } catch (AuthorizationException e) {
          LOGGER.severe("Failed to upload files to Blob Store due to authorization exception.");
-         e.printStackTrace(listener.error("Failed to upload files"));
+         RuntimeException overrideException =
+            new RuntimeException("Failed to upload files to Blob Store due to authorization exception.");
+         overrideException.printStackTrace(listener.error("Failed to upload files"));
          build.setResult(Result.UNSTABLE);
       } catch (IOException e) {
          LOGGER.severe("Failed to upload files to Blob Store: " + e.getMessage());


### PR DESCRIPTION
Really fix JENKINS-16632. We cannot print the AuthorizationException
stack trace because it contains private auth info and printing the stack
trace writes it to the Jenkins build console log. Instead catch
AuthorizationExceptions then create a new RuntimeException whose message
can be printed. Print the RuntimeException stack trace and a helpful
message that authorization failed.
