### PR TITLE
Add support for user data

### DIFF
--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -74,6 +74,10 @@
         <f:textarea />
       </f:entry>
       
+      <f:entry title="User Data (if supported by provider)" field="userData">
+        <f:textarea />
+      </f:entry>
+
       <f:entry title="Jenkins User" field="jenkinsUser">
         <f:textbox />
       </f:entry>

--- a/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -14,7 +14,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
       String name = "testSlave";
       JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", "hardwareId", 1, 512, "osFamily",
                                                                        "osVersion", "jclouds-slave-type1 jclouds-type2", "Description",
-                                                                       "initScript", "1", false, null, null, true, "jenkins", false, null, false, 5, 0);
+                                                                       "initScript", null, "1", false, null, null, true, "jenkins", false, null, false, 5, 0);
 
       List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
       templates.add(originalTemplate);


### PR DESCRIPTION
EC2 and OpenStack support "userdata" field which is particularly for performing initialization of fresh nodes. In some cases it is not possible to use jenkins-plugin without using userdata feature, like when there's no default user with admin or passwordless sudo permissions.

The implementation uses reflection to find out if the provider support userdata option. 
