### PR TITLE
Add floating IP support to openstack-nova and setting the keyPairName.

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -266,6 +266,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             .userMetadata(userMetadata);
 
       ((NovaTemplateOptions)options).autoAssignFloatingIp(true);
+      ((NovaTemplateOptions)options).keyPairName("jenkins");
 
       if( bootstrap != null )
             options.runScript(bootstrap);


### PR DESCRIPTION
The intention of this PR is more for starting a dialog on improving support for openstack-nova in the jclouds-plugin. Currently the plugin does not support a way to set the autoAssignFloatingIp and the keyPairName options on OpenStack instances. This PR hacks in that support.

**DISCLAIMER**
This is a hack and I invite any changes or suggestions to make it better. This change has not been tested on anything other than OpenStack.

With these changes, the instance receives a floating IP but when JClouds tries to login to provision the machine, I get the following error:

```
May 6, 2013 10:39:28 PM net.schmizz.concurrent.Promise tryRetrieve
SEVERE: <<authenticated>> woke to: net.schmizz.sshj.userauth.UserAuthException: password auth failed
May 6, 2013 10:39:28 PM net.schmizz.sshj.transport.TransportImpl$1 notifyDisconnect
INFO: Disconnected - BY_APPLICATION
May 6, 2013 10:39:28 PM org.jclouds.logging.jdk.JDKLogger logError
SEVERE: << (root:pw[4761b3a7b2ebe15d2fee6b5b6727401b]@10.1.200.230:22) error acquiring {hostAndPort=10.1.200.230:22, loginUser=root, ssh=null, connectTimeout=60000, sessionTimeout=60000} (out of retries - max 7): Exhausted available authentication methods
net.schmizz.sshj.userauth.UserAuthException: Exhausted available authentication methods
    at net.schmizz.sshj.userauth.UserAuthImpl.authenticate(UserAuthImpl.java:114)
    at net.schmizz.sshj.SSHClient.auth(SSHClient.java:205)
    at net.schmizz.sshj.SSHClient.auth(SSHClient.java:190)
    at net.schmizz.sshj.SSHClient.authPassword(SSHClient.java:266)
    at net.schmizz.sshj.SSHClient.authPassword(SSHClient.java:236)
    at net.schmizz.sshj.SSHClient.authPassword(SSHClient.java:220)
    at org.jclouds.sshj.SSHClientConnection.create(SSHClientConnection.java:140)
    at org.jclouds.sshj.SSHClientConnection.create(SSHClientConnection.java:40)
    at org.jclouds.sshj.SshjSshClient.acquire(SshjSshClient.java:191)
    at org.jclouds.sshj.SshjSshClient.connect(SshjSshClient.java:221)
    at org.jclouds.compute.callables.RunScriptOnNodeAsInitScriptUsingSsh.call(RunScriptOnNodeAsInitScriptUsingSsh.java:78)
    at org.jclouds.compute.strategy.CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.call(CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.java:163)
    at org.jclouds.compute.strategy.CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.apply(CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.java:184)
    at org.jclouds.compute.strategy.CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.apply(CustomizeNodeAndAddToGoodMapOrPutExceptionIntoBadMap.java:60)
    at com.google.common.util.concurrent.Futures$3.apply(Futures.java:380)
    at com.google.common.util.concurrent.Futures$ChainingListenableFuture.run(Futures.java:522)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(ThreadPoolExecutor.java:895)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:918)
    at java.lang.Thread.run(Thread.java:680)
Caused by: net.schmizz.sshj.userauth.UserAuthException: keyboard-interactive auth not allowed by server
    at net.schmizz.sshj.userauth.UserAuthImpl.authenticate(UserAuthImpl.java:81)
    ... 18 more
```

Suggestions on resolving this welcome.
