### PR TITLE
Fix for connecting into Openstack slaves

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -210,6 +210,8 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
       if (!Strings.isNullOrEmpty(vmPassword)) {
           LoginCredentials lc = LoginCredentials.builder().user(vmUser).password(vmPassword).build();
           options.overrideLoginCredentials(lc);
+      } else if(!Strings.isNullOrEmpty(getCloud().privateKey)){
+          options.overrideLoginPrivateKey(getCloud().privateKey);
       }
 
       if (spoolDelayMs > 0)


### PR DESCRIPTION
Currently OpenStack only supports user/password combination for
XenServer, all others need to use ssh with certificates to be able to
login into the new instance for the first time.

See https://wiki.openstack.org/wiki/HypervisorSupportMatrix

This uses the following logic: if you don't specify a password for the
VM and there is a private key set on the JClouds options, it will use
that to connect to the newly created instance.
