### PR TITLE
Set the default to true, instead of setting the checkbox to true every time.

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -81,7 +81,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
    private final Object delayLockObject = new Object();
    public final boolean assignFloatingIp;
    public final String keyPairName;
-   private final boolean assignPublicIp;
+   public final boolean assignPublicIp;
    
    private transient Set<LabelAtom> labelSet;
 

--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -120,7 +120,7 @@
 
       <f:section title="CloudStack Options">
         <f:entry title="Assign Public IP" field="assignPublicIp">
-          <f:checkbox checked="true"/>
+          <f:checkbox default="true"/>
         </f:entry>
       </f:section>
       


### PR DESCRIPTION
Change field to public to get the current value properly displayed in the advanced section and change the checkbox attribute from checked to default. This fixes a problem where the checkbox would be reset to true every time the config page was loaded.
