### PR TITLE
Fix a non fatal exception during a testrun when injecting LDAPSecurityRealm

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,10 @@
                    <groupId>com.google.guava</groupId>
                    <artifactId>guava</artifactId>
                </exclusion>
+               <exclusion>
+                   <groupId>commons-io</groupId>
+                   <artifactId>commons-io</artifactId>
+               </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
org.apache.commons.io.input.AutoCloseInputStream was introduced in commons-io version 1.4. The stapler dependency made maven select the 1.3.1 version of commons-io.

Fixes this error during test:
Sep 5, 2013 2:34:17 PM hudson.ExtensionFinder$GuiceFinder$4$1 get
WARNING: Failed to instantiate. Skipping this component
com.google.inject.ProvisionException: Guice provision errors:

1) Error injecting constructor, java.lang.NoClassDefFoundError: org/apache/commons/io/input/AutoCloseInputStream
  at hudson.security.LDAPSecurityRealm$DescriptorImpl.<init>(LDAPSecurityRealm.java:551)

1 error
    at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:52)
    at com.google.inject.Scopes$1$1.get(Scopes.java:65)
    at hudson.ExtensionFinder$GuiceFinder$4$1.get(ExtensionFinder.java:420)
    at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:40)
    at com.google.inject.internal.InjectorImpl$4$1.call(InjectorImpl.java:978)
    at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1024)
    at com.google.inject.internal.InjectorImpl$4.get(InjectorImpl.java:974)
    at hudson.ExtensionFinder$GuiceFinder._find(ExtensionFinder.java:389)
    at hudson.ExtensionFinder$GuiceFinder.find(ExtensionFinder.java:380)
    at hudson.ExtensionFinder._find(ExtensionFinder.java:149)
    at hudson.ClassicPluginStrategy.findComponents(ClassicPluginStrategy.java:289)
    at hudson.ExtensionList.load(ExtensionList.java:278)
    at hudson.ExtensionList.ensureLoaded(ExtensionList.java:231)
    at hudson.ExtensionList.getComponents(ExtensionList.java:149)
    at hudson.DescriptorExtensionList.load(DescriptorExtensionList.java:182)
    at hudson.ExtensionList.ensureLoaded(ExtensionList.java:231)
    at hudson.ExtensionList.size(ExtensionList.java:157)
    at java.util.AbstractCollection.isEmpty(AbstractCollection.java:86)
    at hudson.model.labels.LabelAtom.updateTransientActions(LabelAtom.java:107)
    at hudson.model.labels.LabelAtom.load(LabelAtom.java:189)
    at jenkins.model.Jenkins.getLabelAtom(Jenkins.java:1508)
    at jenkins.model.Jenkins.getSelfLabel(Jenkins.java:2374)
    at hudson.model.Node.getAssignedLabels(Node.java:240)
    at jenkins.model.Jenkins$16.run(Jenkins.java:2451)
    at org.jvnet.hudson.reactor.TaskGraphBuilder$TaskImpl.run(TaskGraphBuilder.java:146)
    at org.jvnet.hudson.reactor.Reactor.runTask(Reactor.java:259)
    at jenkins.model.Jenkins$6.runTask(Jenkins.java:838)
    at org.jvnet.hudson.reactor.Reactor$2.run(Reactor.java:187)
    at org.jvnet.hudson.reactor.Reactor$Node.run(Reactor.java:94)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1110)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:603)
    at java.lang.Thread.run(Thread.java:679)
Caused by: java.lang.NoClassDefFoundError: org/apache/commons/io/input/AutoCloseInputStream
    at java.lang.Class.getDeclaredMethods0(Native Method)
    at java.lang.Class.privateGetDeclaredMethods(Class.java:2444)
    at java.lang.Class.getMethod0(Class.java:2687)
    at java.lang.Class.getMethod(Class.java:1620)
    at hudson.model.Descriptor.<init>(Descriptor.java:257)
    at hudson.security.LDAPSecurityRealm$DescriptorImpl.<init>(LDAPSecurityRealm.java:551)
    at hudson.security.LDAPSecurityRealm$DescriptorImpl$$FastClassByGuice$$9c6faba6.newInstance(<generated>)
    at com.google.inject.internal.cglib.reflect.$FastConstructor.newInstance(FastConstructor.java:40)
    at com.google.inject.internal.DefaultConstructionProxyFactory$1.newInstance(DefaultConstructionProxyFactory.java:60)
    at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:85)
    at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:254)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
    at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1031)
    at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
    ... 31 more
Caused by: java.lang.ClassNotFoundException: org.apache.commons.io.input.AutoCloseInputStream
    at java.net.URLClassLoader$1.run(URLClassLoader.java:217)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.net.URLClassLoader.findClass(URLClassLoader.java:205)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:321)
    at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:294)
    at java.lang.ClassLoader.loadClass(ClassLoader.java:266)
    ... 45 more
