### PR TITLE
Add the possibility to add jvmOptions to the slave launch.

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsLauncher.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsLauncher.java
@@ -72,6 +72,14 @@ public class JCloudsLauncher extends ComputerLauncher {
 			scp.put(Hudson.getInstance().getJnlpJars("slave.jar").readFully(), "slave.jar", "/tmp");
 
 			String launchString = "cd /tmp && java -jar slave.jar";
+			if (slave.getJvmOptions() != null && !slave.getJvmOptions().isEmpty()) {
+			    StringBuilder launchStringBuilder = new StringBuilder();
+			    launchStringBuilder.append("cd /tmp && java ");
+			    launchStringBuilder.append(slave.getJvmOptions());
+			    launchStringBuilder.append(" -jar slave.jar");
+			    launchString = launchStringBuilder.toString();
+			}
+			
 			logger.println("Launching slave agent: " + launchString);
 			final Session sess = conn.openSession();
 			sess.execCommand(launchString);

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
@@ -35,11 +35,12 @@ public class JCloudsSlave extends Slave {
 	private String password;
 	private String privateKey;
 	private boolean authSudo;
+	private String jvmOptions;
 
 	@DataBoundConstructor
 	public JCloudsSlave(String cloudName, String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String labelString,
 			ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, boolean stopOnTerminate,
-			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo) throws Descriptor.FormException, IOException {
+			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo, String jvmOptions) throws Descriptor.FormException, IOException {
 		super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
 		this.stopOnTerminate = stopOnTerminate;
 		this.cloudName = cloudName;
@@ -48,6 +49,7 @@ public class JCloudsSlave extends Slave {
 		this.password = password;
 		this.privateKey = privateKey;
 		this.authSudo = authSudo;
+		this.jvmOptions = jvmOptions;
 	}
 
 	/**
@@ -73,14 +75,13 @@ public class JCloudsSlave extends Slave {
 	 * @throws Descriptor.FormException
 	 */
 	public JCloudsSlave(final String cloudName, final String fsRoot, NodeMetadata metadata, final String labelString, final String description,
-			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime) throws IOException, Descriptor.FormException {
+			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime, final String jvmOptions) throws IOException, Descriptor.FormException {
 		this(cloudName, metadata.getName(), description, fsRoot, numExecutors, Mode.EXCLUSIVE, labelString, new JCloudsLauncher(),
 				new JCloudsRetentionStrategy(), Collections.<NodeProperty<?>> emptyList(), stopOnTerminate, overrideRetentionTime, metadata.getCredentials()
 						.getUser(), metadata.getCredentials().getPassword(), metadata.getCredentials().getPrivateKey(), metadata.getCredentials()
-						.shouldAuthenticateSudo());
+						.shouldAuthenticateSudo(),jvmOptions);
 		this.nodeMetaData = metadata;
 		this.nodeId = nodeMetaData.getId();
-
 	}
 
 	/**
@@ -138,6 +139,10 @@ public class JCloudsSlave extends Slave {
 
 	public void setPendingDelete(boolean pendingDelete) {
 		this.pendingDelete = pendingDelete;
+	}
+	
+	public String getJvmOptions() {
+	    return jvmOptions;
 	}
 
 	/**

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -83,6 +83,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 	public final boolean assignFloatingIp;
 	public final String keyPairName;
 	public final boolean assignPublicIp;
+	public final String jvmOptions;
 
 	private transient Set<LabelAtom> labelSet;
 
@@ -93,7 +94,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			final String osVersion, final String labelString, final String description, final String initScript, final String userData,
 			final String numExecutors, final boolean stopOnTerminate, final String vmPassword, final String vmUser, final boolean preInstalledJava,
 			final String jenkinsUser, final boolean preExistingJenkinsUser, final String fsRoot, final boolean allowSudo, final int overrideRetentionTime,
-			final int spoolDelayMs, final boolean assignFloatingIp, final String keyPairName, final boolean assignPublicIp) {
+			final int spoolDelayMs, final boolean assignFloatingIp, final String keyPairName, final boolean assignPublicIp, final String jvmOptions) {
 
 		this.name = Util.fixEmptyAndTrim(name);
 		this.imageId = Util.fixEmptyAndTrim(imageId);
@@ -120,6 +121,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 		this.assignFloatingIp = assignFloatingIp;
 		this.keyPairName = keyPairName;
 		this.assignPublicIp = assignPublicIp;
+		this.jvmOptions = jvmOptions;
 		readResolve();
 	}
 
@@ -164,7 +166,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
 		try {
 			return new JCloudsSlave(getCloud().getDisplayName(), getFsRoot(), nodeMetadata, labelString, description, numExecutors, stopOnTerminate,
-					overrideRetentionTime);
+					overrideRetentionTime, jvmOptions);
 		} catch (Descriptor.FormException e) {
 			throw new AssertionError("Invalid configuration " + e.getMessage());
 		}

--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -108,6 +108,10 @@
       <f:entry title="${%Stop on Terminate}" field="stopOnTerminate">
         <f:checkbox />
       </f:entry>
+
+      <f:entry title="JVM Options" field="jvmOptions">
+        <f:textbox />
+      </f:entry>
       
       <f:section title="Open Stack Options">
       	<f:entry title="Assign Floating IP" field="assignFloatingIp">

--- a/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -14,7 +14,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
 		String name = "testSlave";
 		JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", "hardwareId", 1, 512, "osFamily", "osVersion",
 				"jclouds-slave-type1 jclouds-type2", "Description", "initScript", null, "1", false, null, null, true, "jenkins", false, null, false, 5, 0,
-				true, "jenkins", true);
+				true, "jenkins", true, null);
 
 		List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
 		templates.add(originalTemplate);


### PR DESCRIPTION
Currently the slave.jar is started with just the default java settings. There is no way for the admin to set additional options. I need this to be able to set a git timeout, but it might also be good to have this to set memory limits or other java command line options.

jclouds (cloudstack) slave log from a Jenkins 1.456 instance running with this patch:
Connecting to x.x.x.x on port 22. 
Connected via SSH.
Authenticating as jenkins
Copying slave.jar
Launching slave agent: cd /tmp && java -Dorg.jenkinsci.plugins.gitclient.Git.timeOut=400 -jar slave.jar
<===[JENKINS REMOTING CAPACITY]===>Slave.jar version: 2.33
This is a Unix slave
Evacuated stdout
Slave successfully connected and online
