### PR TITLE
Use the shaded dependency also in static imports

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -1,7 +1,7 @@
 package jenkins.plugins.jclouds.compute;
 
-import static com.google.common.base.Throwables.propagate;
-import static com.google.common.collect.Iterables.getOnlyElement;
+import static shaded.com.google.common.base.Throwables.propagate;
+import static shaded.com.google.common.collect.Iterables.getOnlyElement;
 import static org.jclouds.scriptbuilder.domain.Statements.newStatementList;
 
 import java.io.IOException;

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreTestFixture.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreTestFixture.java
@@ -1,6 +1,6 @@
 package jenkins.plugins.jclouds.blobstore;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static shaded.com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/ComputeTestFixture.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/ComputeTestFixture.java
@@ -1,6 +1,6 @@
 package jenkins.plugins.jclouds.compute;
 
-import static com.google.common.base.Preconditions.checkNotNull;
+import static shaded.com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Map;
 


### PR DESCRIPTION
Static imports were not using the `shaded` dependency and a `ClassNotFoundException` appeared at runtime.
