### PR TITLE
Added the DigitalOcean provider

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -23,6 +23,11 @@
             <version>${jclouds.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.jclouds.labs</groupId>
+            <artifactId>digitalocean</artifactId>
+            <version>${jclouds.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.jclouds</groupId>
             <artifactId>jclouds-allblobstore</artifactId>
             <version>${jclouds.version}</version>


### PR DESCRIPTION
After upgrading the plugin to use the 1.7.1 release, the DigitalOcean provider is available and can be used.
