### PR TITLE
Capability to terminate or suspend or leave additional VMs running

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/InstancesToRun.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/InstancesToRun.java
@@ -1,7 +1,5 @@
 package jenkins.plugins.jclouds.compute;
 
-import java.io.Serializable;
-
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
@@ -9,26 +7,23 @@ import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 
-import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
-import org.kohsuke.stapler.export.Exported;
-import org.kohsuke.stapler.export.ExportedBean;
 
 public final class InstancesToRun extends AbstractDescribableImpl<InstancesToRun> {
 	public final String cloudName;
 	public final String templateName;
 	public final String manualTemplateName;
 	public final int count;
-	public final boolean suspendOrTerminate;
+	public final String actionOnBuildFinish;
 
 	@DataBoundConstructor
-	public InstancesToRun(String cloudName, String templateName, String manualTemplateName, int count, boolean suspendOrTerminate) {
+	public InstancesToRun(String cloudName, String templateName, String manualTemplateName, int count, String actionOnBuildFinish) {
 		this.cloudName = Util.fixEmptyAndTrim(cloudName);
 		this.templateName = Util.fixEmptyAndTrim(templateName);
 		this.manualTemplateName = Util.fixEmptyAndTrim(manualTemplateName);
 		this.count = count;
-		this.suspendOrTerminate = suspendOrTerminate;
+		this.actionOnBuildFinish = actionOnBuildFinish;
 	}
 
 	public String getActualTemplateName() {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper.java
@@ -76,7 +76,7 @@ public class JCloudsBuildWrapper extends BuildWrapper {
 				Supplier<NodeMetadata> nodeSupplier = JCloudsCloud.getByName(cloudName).getTemplate(templateName);
 				// take the hit here, as opposed to later
 				computeCache.getUnchecked(cloudName);
-				return new NodePlan(cloudName, templateName, instance.count, instance.suspendOrTerminate, nodeSupplier);
+				return new NodePlan(cloudName, templateName, instance.count, instance.actionOnBuildFinish, nodeSupplier);
 			}
 
 		});

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/NodePlan.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/NodePlan.java
@@ -8,14 +8,14 @@ public class NodePlan {
 	private final String cloudName;
 	private final String templateName;
 	private final int count;
-	private final boolean suspendOrTerminate;
+	private final String actionOnBuildFinish;
 	private final Supplier<NodeMetadata> nodeSupplier;
 
-	public NodePlan(String cloud, String template, int count, boolean suspendOrTerminate, Supplier<NodeMetadata> nodeSupplier) {
+	public NodePlan(String cloud, String template, int count, String actionOnBuildFinish, Supplier<NodeMetadata> nodeSupplier) {
 		this.cloudName = cloud;
 		this.templateName = template;
 		this.count = count;
-		this.suspendOrTerminate = suspendOrTerminate;
+		this.actionOnBuildFinish = actionOnBuildFinish;
 		this.nodeSupplier = nodeSupplier;
 	}
 
@@ -31,8 +31,8 @@ public class NodePlan {
 		return count;
 	}
 
-	public boolean isSuspendOrTerminate() {
-		return suspendOrTerminate;
+	public String getActionOnBuildFinish() {
+		return actionOnBuildFinish;
 	}
 
 	public Supplier<NodeMetadata> getNodeSupplier() {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/ProvisionPlannedInstancesAndDestroyAllOnError.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/ProvisionPlannedInstancesAndDestroyAllOnError.java
@@ -41,7 +41,7 @@ public class ProvisionPlannedInstancesAndDestroyAllOnError implements Function<I
 				Futures.addCallback(provisionTemplate, new FutureCallback<NodeMetadata>() {
 					public void onSuccess(NodeMetadata result) {
 						if (result != null) {
-							cloudTemplateNodeBuilder.add(new RunningNode(nodePlan.getCloudName(), nodePlan.getTemplateName(), nodePlan.isSuspendOrTerminate(),
+							cloudTemplateNodeBuilder.add(new RunningNode(nodePlan.getCloudName(), nodePlan.getTemplateName(), nodePlan.getActionOnBuildFinish(),
 									result));
 						} else {
 							failedLaunches.incrementAndGet();

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/RunningNode.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/RunningNode.java
@@ -3,31 +3,45 @@ package jenkins.plugins.jclouds.compute.internal;
 import org.jclouds.compute.domain.NodeMetadata;
 
 public class RunningNode {
-	private final String cloud;
-	private final String template;
-	private final boolean suspendOrTerminate;
-	private final NodeMetadata node;
 
-	public RunningNode(String cloud, String template, boolean suspendOrTerminate, NodeMetadata node) {
-		this.cloud = cloud;
-		this.template = template;
-		this.suspendOrTerminate = suspendOrTerminate;
-		this.node = node;
-	}
+  private final String cloud;
+  private final String template;
+  private final String actionOnBuildFinish;
+  private final NodeMetadata node;
+  
+  public static final String ACTION_TERMINATE = "terminate";
+  public static final String ACTION_SUSPEND = "suspend";
+  public static final String ACTION_LEAVE = "leave";
 
-	public String getCloudName() {
-		return cloud;
-	}
+  public RunningNode(final String cloud, final String template, final String actionOnBuildFinish,
+                     final NodeMetadata node) {
+    this.cloud = cloud;
+    this.template = template;
+    this.actionOnBuildFinish = actionOnBuildFinish;
+    this.node = node;
+  }
 
-	public String getTemplateName() {
-		return template;
-	}
+  public String getCloudName() {
+    return cloud;
+  }
 
-	public boolean isSuspendOrTerminate() {
-		return suspendOrTerminate;
-	}
+  public String getTemplateName() {
+    return template;
+  }
 
-	public NodeMetadata getNode() {
-		return node;
-	}
+  public boolean shouldTerminate() {
+    return actionOnBuildFinish.equals(ACTION_TERMINATE);
+  }
+  
+  public boolean shouldSuspend() {
+    return actionOnBuildFinish.equals(ACTION_SUSPEND);
+  }
+  
+  public boolean shouldLeave() {
+    return actionOnBuildFinish.equals(ACTION_LEAVE);
+  }
+
+  public NodeMetadata getNode() {
+    return node;
+  }
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/TerminateNodes.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/internal/TerminateNodes.java
@@ -25,18 +25,22 @@ public class TerminateNodes implements Function<Iterable<RunningNode>, Void> {
 	public Void apply(Iterable<RunningNode> runningNode) {
 		Builder<String, String> cloudNodesToSuspendBuilder = ImmutableMultimap.<String, String> builder();
 		Builder<String, String> cloudNodesToDestroyBuilder = ImmutableMultimap.<String, String> builder();
+		Builder<String, String> cloudNodesToLeaveBuilder = ImmutableMultimap.<String, String> builder();
 		for (RunningNode cloudTemplateNode : runningNode) {
-			if (cloudTemplateNode.isSuspendOrTerminate()) {
+			if (cloudTemplateNode.shouldSuspend()) {
 				cloudNodesToSuspendBuilder.put(cloudTemplateNode.getCloudName(), cloudTemplateNode.getNode().getId());
-			} else {
+			} else if (cloudTemplateNode.shouldTerminate()) {
 				cloudNodesToDestroyBuilder.put(cloudTemplateNode.getCloudName(), cloudTemplateNode.getNode().getId());
-			}
+			} else if (cloudTemplateNode.shouldLeave()) {
+                                cloudNodesToLeaveBuilder.put(cloudTemplateNode.getCloudName(), cloudTemplateNode.getNode().getId());
+                        }
 		}
 		Multimap<String, String> cloudNodesToSuspend = cloudNodesToSuspendBuilder.build();
 		Multimap<String, String> cloudNodesToDestroy = cloudNodesToDestroyBuilder.build();
 
 		suspendIfSupported(cloudNodesToSuspend);
 		destroy(cloudNodesToDestroy);
+		logger.info("Leaving the following nodes running: " + cloudNodesToLeaveBuilder.build() + ". You should terminate them manually.");
 		return null;
 	}
 

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/config.jelly
@@ -22,8 +22,13 @@
     <f:textbox />
   </f:entry>
   
-  <f:entry title="${%Stop on Terminate}" field="suspendOrTerminate">
-    <f:checkbox />
+  <f:entry title="${%Action when build is finished}">
+      <f:radioBlock inline="true" name="jclouds.actionOnBuildFinish" value="terminate"
+                    title="Terminate instance" checked="${(instance.actionOnBuildFinish == null) || instance.actionOnBuildFinish.equals(&quot;terminate&quot;)}" />
+      <f:radioBlock inline="true" name="jclouds.actionOnBuildFinish" value="suspend"
+                    title="Suspend instance" checked="${instance.actionOnBuildFinish.equals(&quot;suspend&quot;)}" />
+      <f:radioBlock inline="true" name="jclouds.actionOnBuildFinish" value="leave"
+                    title="Leave instance running" checked="${instance.actionOnBuildFinish.equals(&quot;leave&quot;)}" />
   </f:entry>
   
   <f:entry>


### PR DESCRIPTION
Right now we have a checkbox "Stop on Terminate" in build environment section under "JClouds Instance Creation". I replaced it with radio group allowing to select one of 3 options: terminate instance (default), suspend instance and leave instance running. The first two options existed before. The use case for the third one is the following: we're using the plugin to dynamically prepare testing virtual machines. What we need when build is finished is that VM should remain running and the user is intended to terminate instances manually.
