### PR TITLE
Encrypt password for storage and html

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -29,6 +29,7 @@ import hudson.slaves.NodeProvisioner;
 import hudson.slaves.NodeProvisioner.PlannedNode;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
 import hudson.util.StreamTaskListener;
 import jenkins.model.Jenkins;
 import org.jclouds.Constants;
@@ -68,7 +69,7 @@ public class JCloudsCloud extends Cloud {
 	static final Logger LOGGER = Logger.getLogger(JCloudsCloud.class.getName());
 
 	public final String identity;
-	public final String credential;
+	public final Secret credential;
 	public final String providerName;
 
 	public final String privateKey;
@@ -106,7 +107,7 @@ public class JCloudsCloud extends Cloud {
 		this.profile = Util.fixEmptyAndTrim(profile);
 		this.providerName = Util.fixEmptyAndTrim(providerName);
 		this.identity = Util.fixEmptyAndTrim(identity);
-		this.credential = Util.fixEmptyAndTrim(credential);
+		this.credential = Secret.fromString(credential);
 		this.privateKey = privateKey;
 		this.publicKey = publicKey;
 		this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
@@ -173,7 +174,7 @@ public class JCloudsCloud extends Cloud {
 			if (startTimeout > 0) {
 				overrides.setProperty(ComputeServiceProperties.TIMEOUT_NODE_RUNNING, String.valueOf(startTimeout));
 			}
-			this.compute = ctx(this.providerName, this.identity, this.credential, overrides, this.zones).getComputeService();
+			this.compute = ctx(this.providerName, this.identity, Secret.toString(credential), overrides, this.zones).getComputeService();
 		}
 		return compute;
 	}
@@ -328,7 +329,7 @@ public class JCloudsCloud extends Cloud {
 			// Remove empty text/whitespace from the fields.
 			providerName = Util.fixEmptyAndTrim(providerName);
 			identity = Util.fixEmptyAndTrim(identity);
-			credential = Util.fixEmptyAndTrim(credential);
+			credential = Secret.fromString(credential).getPlainText();
 			endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
 			zones = Util.fixEmptyAndTrim(zones);
 

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -27,6 +27,7 @@ import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.Secret;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
@@ -420,7 +421,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			imageId = Util.fixEmptyAndTrim(imageId);
 
 			try {
-				final Set<? extends Image> images = listImages(providerName, identity, credential, endPointUrl, zones);
+				final Set<? extends Image> images = listImages(providerName, identity, Secret.fromString(credential).getPlainText(), endPointUrl, zones);
 				if (images != null) {
 					for (final Image image : images) {
 						if (!image.getId().equals(imageId)) {
@@ -441,7 +442,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 		public FormValidation doValidateImageNameRegex(@QueryParameter String providerName, @QueryParameter String identity, @QueryParameter String credential,
 				@QueryParameter String endPointUrl, @QueryParameter String imageNameRegex, @QueryParameter String zones) {
 
-			final FormValidation computeContextValidationResult = validateComputeContextParameters(providerName, identity, credential, endPointUrl, zones);
+			final FormValidation computeContextValidationResult = validateComputeContextParameters(providerName, identity, Secret.fromString(credential).getPlainText(), endPointUrl, zones);
 			if (computeContextValidationResult != null) {
 				return computeContextValidationResult;
 			}
@@ -453,7 +454,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			imageNameRegex = Util.fixEmptyAndTrim(imageNameRegex);
 
 			try {
-				final Set<? extends Image> images = listImages(providerName, identity, credential, endPointUrl, zones);
+				final Set<? extends Image> images = listImages(providerName, identity, Secret.fromString(credential).getPlainText(), endPointUrl, zones);
 				if (images != null) {
 					for (final Image image : images) {
 						if (image.getName().matches(imageNameRegex)) {
@@ -486,7 +487,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			// Remove empty text/whitespace from the fields.
 			providerName = Util.fixEmptyAndTrim(providerName);
 			identity = Util.fixEmptyAndTrim(identity);
-			credential = Util.fixEmptyAndTrim(credential);
+			credential = Secret.fromString(credential).getPlainText();
 			endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
 			zones = Util.fixEmptyAndTrim(zones);
 			ComputeService computeService = null;
@@ -523,7 +524,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			// Remove empty text/whitespace from the fields.
 			providerName = Util.fixEmptyAndTrim(providerName);
 			identity = Util.fixEmptyAndTrim(identity);
-			credential = Util.fixEmptyAndTrim(credential);
+			credential = Secret.fromString(credential).getPlainText();
 			endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
 
 			ComputeService computeService = null;
@@ -568,7 +569,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			// Remove empty text/whitespace from the fields.
 			providerName = Util.fixEmptyAndTrim(providerName);
 			identity = Util.fixEmptyAndTrim(identity);
-			credential = Util.fixEmptyAndTrim(credential);
+			credential = Secret.fromString(credential).getPlainText();
 			hardwareId = Util.fixEmptyAndTrim(hardwareId);
 			endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
 			zones = Util.fixEmptyAndTrim(zones);
@@ -621,7 +622,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
          // Remove empty text/whitespace from the fields.
          providerName = Util.fixEmptyAndTrim(providerName);
          identity = Util.fixEmptyAndTrim(identity);
-         credential = Util.fixEmptyAndTrim(credential);
+         credential = Secret.fromString(credential).getPlainText();
          endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
 
          ComputeService computeService = null;


### PR DESCRIPTION
This PR adds use of hudson.util.Secret for storage and html values in browser so that credentials are not stored and passed around in the browser in clear text.
