### PR TITLE
Add possibility to start pre-configured auto-login Windows slaves in "hybrid ssh-jnlp mode"

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -212,7 +212,7 @@ public class JCloudsCloud extends Cloud {
 						provisioning until the launch goes successful prevents this
 						problem.  */
 
-					int timeout = 60 * 1000;
+					int timeout = slave.getGuestOsStartupTimeout() * 1000;
 					int counter = 0;
 					int retryStep = 15 * 1000;
 					Computer computer = slave.toComputer();
@@ -225,7 +225,13 @@ public class JCloudsCloud extends Cloud {
 						try {
 							computer.connect(false).get();
 						} catch(Exception e) {
-							continue;
+							if (counter > timeout) {
+								LOGGER.info(
+										String.format("Failed to connect to slave within timeout (%d ms).", timeout));
+								throw e;
+							} else {
+								continue;
+							}
 						}
 						break;
 					}

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -201,7 +201,7 @@ public class JCloudsCloud extends Cloud {
 			r.add(new PlannedNode(t.name, Computer.threadPoolForRemoting.submit(new Callable<Node>() {
 				public Node call() throws Exception {
 					// TODO: record the output somewhere
-					JCloudsSlave slave = template.provisionSlave(StreamTaskListener.fromStdout());
+					JCloudsSlave slave = t.provisionSlave(StreamTaskListener.fromStdout());
 					Jenkins.getInstance().addNode(slave);
 					/* Cloud instances may have a long init script. If we declare
 						the provisioning complete by returning without the connect

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsLauncher.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsLauncher.java
@@ -10,6 +10,8 @@ import hudson.slaves.SlaveComputer;
 import java.io.IOException;
 import java.io.PrintStream;
 
+import jenkins.model.Jenkins;
+
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.domain.LoginCredentials;
 
@@ -41,6 +43,7 @@ public class JCloudsLauncher extends ComputerLauncher {
 
 		PrintStream logger = listener.getLogger();
 
+		final Jenkins jenkins = Jenkins.getInstance();
 		final Connection bootstrapConn;
 		final Connection conn;
 		Connection cleanupConn = null; // java's code path analysis for final doesn't work that well.
@@ -101,6 +104,29 @@ public class JCloudsLauncher extends ComputerLauncher {
 				cleanupConn.close();
 		}
 	}
+
+    /**
+     * Copies Slave.jar to a given destination using provided connection.
+     *
+     * @param connection {@link Connection} to a remote host.
+     * @param destinationFolder {@link String} with an absolute path to a folder to copy slave.jar
+     *                          to.
+     * @param logger {@link PrintStream} to log status to.
+     * @throws IOException If copying went wrong.
+     */
+    private static void copySlaveJarTo(
+            Connection connection, String destinationFolder, PrintStream logger)
+                    throws IOException {
+        SCPClient scp = connection.createSCPClient();
+        logger.println(
+                String.format(
+                        "Copying slave.jar to %s:%s...",
+                        connection.getHostname(),
+                        destinationFolder));
+        scp.put(Jenkins.getInstance().getJnlpJars("slave.jar").readFully(),
+                "slave.jar", destinationFolder);
+        logger.println("slave.jar was copied successfully.");
+    }
 
 	/**
 	 * Authenticate with credentials

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsLauncher.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsLauncher.java
@@ -78,13 +78,14 @@ public class JCloudsLauncher extends ComputerLauncher {
 						String.format(
 								JCloudsSlave.GuestOS.CREATE_LAUNCH_SCRIPT_TEMPLATE,
 								String.format(
+										slave.getJvmOptions(),
 										JCloudsSlave.GuestOS.JNLP_URL_TEMPLATE,
 										jenkins.getRootUrl(),
 										computer.getName()));
 				sess.execCommand(createLaunchScript);
 			} else if (JCloudsSlave.GuestOS.UNIX.toString().equals(slave.getGuestOS())) {
 				JCloudsLauncher.copySlaveJarTo(conn, "/tmp", logger);
-				String launchString = "java  -jar /tmp/slave.jar";
+				String launchString = "java -jar " + slave.getJvmOptions() + " /tmp/slave.jar";
 				sess.execCommand(launchString);
 			} else {
 				conn.close();

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
@@ -38,6 +38,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	private final String password;
 	private final String privateKey;
 	private final String guestOS;
+	private final int guestOsStartupTimeout;
 	private final boolean authSudo;
 	private final String jvmOptions;
 
@@ -45,7 +46,8 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	@SuppressWarnings("rawtypes")
 	public JCloudsSlave(String cloudName, String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String labelString,
 			ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, boolean stopOnTerminate,
-			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo, String jvmOptions, String guestOS) throws Descriptor.FormException,
+			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo, String jvmOptions, String guestOS,
+			int guestOsStartupTimeout) throws Descriptor.FormException,
 			IOException {
 		super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
 		this.stopOnTerminate = stopOnTerminate;
@@ -57,6 +59,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 		this.authSudo = authSudo;
 		this.jvmOptions = jvmOptions;
 		this.guestOS = guestOS;
+		this.guestOsStartupTimeout = guestOsStartupTimeout;
 	}
 
 	/**
@@ -84,12 +87,13 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	 * @throws Descriptor.FormException
 	 */
 	public JCloudsSlave(final String cloudName, final String fsRoot, NodeMetadata metadata, final String labelString, final String description,
-			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime, String jvmOptions, final String guestOS) throws IOException,
+			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime, String jvmOptions, final String guestOS,
+			final int guestOsStartupTimeout) throws IOException,
 			Descriptor.FormException {
 		this(cloudName, metadata.getName(), description, fsRoot, numExecutors, Mode.EXCLUSIVE, labelString, new JCloudsLauncher(),
 				new JCloudsRetentionStrategy(), Collections.<NodeProperty<?>> emptyList(), stopOnTerminate, overrideRetentionTime, metadata.getCredentials()
 						.getUser(), metadata.getCredentials().getPassword(), metadata.getCredentials().getPrivateKey(), metadata.getCredentials()
-						.shouldAuthenticateSudo(), jvmOptions, guestOS);
+						.shouldAuthenticateSudo(), jvmOptions, guestOS, guestOsStartupTimeout);
 		this.nodeMetaData = metadata;
 		this.nodeId = nodeMetaData.getId();
 	}
@@ -163,6 +167,10 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	public String getGuestOS() {
 		return guestOS;
 	}
+	
+	public int getGuestOsStartupTimeout() {
+		return guestOsStartupTimeout;
+	}
 
 	/**
 	 * {@inheritDoc}
@@ -216,14 +224,14 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	 * @author iakovenko
 	 */
 	public enum GuestOS {
-		JNLP_WINDOWS("Pre-configured Windows that starts slave over JNLP", "win", true),
+		JNLP_WINDOWS("Pre-configured Windows that starts slave over JNLP", "win", false),
 		UNIX("Unix", "unix", false);
 
 		public static final String JENKINS_SCRIPTS_LOCATION = "/cygdrive/c/start";
 		public static final String JNLP_URL_TEMPLATE = "%scomputer/%s/slave-agent.jnlp";
 		public static final String CREATE_LAUNCH_SCRIPT_TEMPLATE =
-				"echo 'cd C:\\start & java -jar slave.jar -jnlpUrl " +
-						"\"%s\"' >> " + JENKINS_SCRIPTS_LOCATION + "/agent-launcher.bat";
+				"echo 'cd C:\\start & java %s -jar slave.jar -jnlpUrl " +
+				"\"%s\"' >> " + JENKINS_SCRIPTS_LOCATION + "/agent-launcher.bat";
 
 		private final String longName;
 		private final String shortName;

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
@@ -89,7 +89,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 		this(cloudName, metadata.getName(), description, fsRoot, numExecutors, Mode.EXCLUSIVE, labelString, new JCloudsLauncher(),
 				new JCloudsRetentionStrategy(), Collections.<NodeProperty<?>> emptyList(), stopOnTerminate, overrideRetentionTime, metadata.getCredentials()
 						.getUser(), metadata.getCredentials().getPassword(), metadata.getCredentials().getPrivateKey(), metadata.getCredentials()
-						.shouldAuthenticateSudo(), jvmOption, guestOSs);
+						.shouldAuthenticateSudo(), jvmOptions, guestOS);
 		this.nodeMetaData = metadata;
 		this.nodeId = nodeMetaData.getId();
 	}

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
@@ -8,6 +8,7 @@ import hudson.slaves.AbstractCloudSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.ComputerLauncher;
 import hudson.slaves.RetentionStrategy;
+import hudson.util.ListBoxModel.Option;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class JCloudsSlave extends AbstractCloudSlave {
 	private static final Logger LOGGER = Logger.getLogger(JCloudsSlave.class.getName());
+
 	private transient NodeMetadata nodeMetaData;
 	public final boolean stopOnTerminate;
 	private final String cloudName;
@@ -35,6 +37,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	private final String user;
 	private final String password;
 	private final String privateKey;
+	private final String guestOS;
 	private final boolean authSudo;
 	private final String jvmOptions;
 
@@ -42,7 +45,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	@SuppressWarnings("rawtypes")
 	public JCloudsSlave(String cloudName, String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String labelString,
 			ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, boolean stopOnTerminate,
-			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo, String jvmOptions) throws Descriptor.FormException,
+			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo, String jvmOptions, String guestOS) throws Descriptor.FormException,
 			IOException {
 		super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
 		this.stopOnTerminate = stopOnTerminate;
@@ -53,6 +56,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 		this.privateKey = privateKey;
 		this.authSudo = authSudo;
 		this.jvmOptions = jvmOptions;
+		this.guestOS = guestOS;
 	}
 
 	/**
@@ -74,16 +78,18 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	 *            - if true, suspend the slave rather than terminating it.
 	 * @param overrideRetentionTime
 	 *            - Retention time to use specifically for this slave, overriding the cloud default.
+	 * @param guestOS
+	 *            - Type of guest operating system.
 	 * @throws IOException
 	 * @throws Descriptor.FormException
 	 */
 	public JCloudsSlave(final String cloudName, final String fsRoot, NodeMetadata metadata, final String labelString, final String description,
-			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime, String jvmOptions) throws IOException,
+			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime, String jvmOptions, final String guestOS) throws IOException,
 			Descriptor.FormException {
 		this(cloudName, metadata.getName(), description, fsRoot, numExecutors, Mode.EXCLUSIVE, labelString, new JCloudsLauncher(),
 				new JCloudsRetentionStrategy(), Collections.<NodeProperty<?>> emptyList(), stopOnTerminate, overrideRetentionTime, metadata.getCredentials()
 						.getUser(), metadata.getCredentials().getPassword(), metadata.getCredentials().getPrivateKey(), metadata.getCredentials()
-						.shouldAuthenticateSudo(), jvmOptions);
+						.shouldAuthenticateSudo(), jvmOption, guestOSs);
 		this.nodeMetaData = metadata;
 		this.nodeId = nodeMetaData.getId();
 	}
@@ -130,7 +136,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	 * @return overrideTime
 	 */
 	public int getRetentionTime() {
-		if (overrideRetentionTime > 0) {
+		if (overrideRetentionTime > 0 || overrideRetentionTime == -1) {
 			return overrideRetentionTime;
 		} else {
 			return JCloudsCloud.getByName(cloudName).getRetentionTime();
@@ -152,6 +158,10 @@ public class JCloudsSlave extends AbstractCloudSlave {
 
 	public void setPendingDelete(boolean pendingDelete) {
 		this.pendingDelete = pendingDelete;
+	}
+
+	public String getGuestOS() {
+		return guestOS;
 	}
 
 	/**
@@ -199,4 +209,62 @@ public class JCloudsSlave extends AbstractCloudSlave {
 			LOGGER.info("Slave " + getNodeName() + " is already not running.");
 		}
 	}
+
+	/**
+	 * Enumerate for supported JClouds guest operating systems.
+	 *
+	 * @author iakovenko
+	 */
+	public enum GuestOS {
+		JNLP_WINDOWS("Pre-configured Windows that starts slave over JNLP", "win", true),
+		UNIX("Unix", "unix", false);
+
+		public static final String JENKINS_SCRIPTS_LOCATION = "/cygdrive/c/start";
+		public static final String JNLP_URL_TEMPLATE = "%scomputer/%s/slave-agent.jnlp";
+		public static final String CREATE_LAUNCH_SCRIPT_TEMPLATE =
+				"echo 'cd C:\\start & java -jar slave.jar -jnlpUrl " +
+						"\"%s\"' >> " + JENKINS_SCRIPTS_LOCATION + "/agent-launcher.bat";
+
+		private final String longName;
+		private final String shortName;
+		private final boolean selected;
+
+		private GuestOS(String longName, String shortName, boolean selected) {
+			this.longName = longName;
+			this.shortName = shortName;
+			this.selected = selected;
+		}
+
+		public Option toOption() {
+			return new Option(longName, shortName, selected);
+		}
+
+		/**
+		 * @return the longName
+		 */
+		public String getLongName() {
+			return longName;
+		}
+
+		/**
+		 * @return the shortName
+		 */
+		public String getShortName() {
+			return shortName;
+		}
+
+		/**
+		 * @return the selected
+		 */
+		public boolean isSelected() {
+			return selected;
+		}
+
+		@Override
+		public String toString() {
+			return shortName;
+		}
+	}
+
+
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -27,6 +27,7 @@ import hudson.model.TaskListener;
 import hudson.model.labels.LabelAtom;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
+import hudson.util.ListBoxModel.Option;
 import jenkins.model.Jenkins;
 
 import org.apache.commons.lang.StringUtils;
@@ -94,9 +95,9 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 	public final boolean assignFloatingIp;
 	public final String keyPairName;
 	public final boolean assignPublicIp;
-        public final String networks;
-        public final String securityGroups;
-
+	public final String networks;
+	public final String securityGroups;
+	public final String guestOS;
 	private transient Set<LabelAtom> labelSet;
 
 	protected transient JCloudsCloud cloud;
@@ -107,7 +108,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			final String initScript, final String userData, final String numExecutors, final boolean stopOnTerminate, final String vmPassword, final String vmUser,
 			final boolean preInstalledJava, final String jvmOptions, final String jenkinsUser, final boolean preExistingJenkinsUser, final String fsRoot,
 			final boolean allowSudo, final boolean installPrivateKey, final int overrideRetentionTime, final int spoolDelayMs, final boolean assignFloatingIp,
-			final String keyPairName, final boolean assignPublicIp, final String networks, final String securityGroups) {
+			final String keyPairName, final boolean assignPublicIp, final String networks, final String securityGroups, final String guestOS) {
 
 		this.name = Util.fixEmptyAndTrim(name);
 		this.imageId = Util.fixEmptyAndTrim(imageId);
@@ -138,8 +139,9 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 		this.assignFloatingIp = assignFloatingIp;
 		this.keyPairName = keyPairName;
 		this.assignPublicIp = assignPublicIp;
-                this.networks = networks;
-                this.securityGroups = securityGroups;
+		this.networks = networks;
+		this.securityGroups = securityGroups;
+		this.guestOS = guestOS;
 		readResolve();
 	}
 
@@ -192,7 +194,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
 		try {
 			return new JCloudsSlave(getCloud().getDisplayName(), getFsRoot(), nodeMetadata, labelString, description, numExecutors, stopOnTerminate,
-					overrideRetentionTime, getJvmOptions());
+					overrideRetentionTime, getJvmOptions(), guestOS);
 		} catch (Descriptor.FormException e) {
 			throw new AssertionError("Invalid configuration " + e.getMessage());
 		}
@@ -499,6 +501,14 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 					computeService.getContext().close();
 				}
 			}
+		}
+
+		public ListBoxModel doFillGuestOSItems() {
+			return new ListBoxModel(
+					ImmutableList.<Option>of(
+							JCloudsSlave.GuestOS.JNLP_WINDOWS.toOption(),
+							JCloudsSlave.GuestOS.UNIX.toOption())
+			);
 		}
 
 		public ListBoxModel doFillHardwareIdItems(@RelativePath("..") @QueryParameter String providerName, @RelativePath("..") @QueryParameter String identity,

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -99,6 +99,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 	public final String networks;
 	public final String securityGroups;
 	public final String guestOS;
+	public final int guestOsStartupTimeout;
 	private transient Set<LabelAtom> labelSet;
 
 	protected transient JCloudsCloud cloud;
@@ -109,7 +110,8 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			final String initScript, final String userData, final String numExecutors, final boolean stopOnTerminate, final String vmPassword, final String vmUser,
 			final boolean preInstalledJava, final String jvmOptions, final String jenkinsUser, final boolean preExistingJenkinsUser, final String fsRoot,
 			final boolean allowSudo, final boolean installPrivateKey, final int overrideRetentionTime, final int spoolDelayMs, final boolean assignFloatingIp,
-			final String keyPairName, final boolean assignPublicIp, final String networks, final String securityGroups, final String guestOS) {
+			final String keyPairName, final boolean assignPublicIp, final String networks, final String securityGroups, final String guestOS,
+			final int guestOsStartupTimeout) {
 
 		this.name = Util.fixEmptyAndTrim(name);
 		this.imageId = Util.fixEmptyAndTrim(imageId);
@@ -143,6 +145,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 		this.networks = networks;
 		this.securityGroups = securityGroups;
 		this.guestOS = guestOS;
+		this.guestOsStartupTimeout = guestOsStartupTimeout;
 		readResolve();
 	}
 
@@ -195,7 +198,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
 		try {
 			return new JCloudsSlave(getCloud().getDisplayName(), getFsRoot(), nodeMetadata, labelString, description, numExecutors, stopOnTerminate,
-					overrideRetentionTime, getJvmOptions(), guestOS);
+					overrideRetentionTime, getJvmOptions(), guestOS, guestOsStartupTimeout);
 		} catch (Descriptor.FormException e) {
 			throw new AssertionError("Invalid configuration " + e.getMessage());
 		}

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -56,6 +56,7 @@ import au.com.bytecode.opencsv.CSVReader;
 import shaded.com.google.common.base.Strings;
 import shaded.com.google.common.base.Supplier;
 import shaded.com.google.common.collect.ImmutableMap;
+import shaded.com.google.common.collect.ImmutableList;
 
 /**
  * @author Vijay Kiran

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -134,13 +134,6 @@
           <f:checkbox />
         </f:entry>
 
-        <f:entry title="Guest OS" field="guestOS">
-          <f:select name="guestOS">
-            <f:option value="win">Prepared Windows</f:option>
-            <f:option value="unix">Unix</f:option>
-          </f:select>
-        </f:entry>
-
         <f:entry title="Networks" field="networks">
           <f:textbox />
         </f:entry>
@@ -149,7 +142,7 @@
           <f:textbox />
         </f:entry>
       </f:section>
-      
+
       <f:section title="Open Stack Options">
         <f:entry title="Assign Floating IP" field="assignFloatingIp">
           <f:checkbox />
@@ -157,6 +150,18 @@
         <f:entry title="Key Pair Name" field="keyPairName">
           <f:textbox />
         </f:entry>
+
+        <f:advanced>
+                <f:entry title="Guest OS" field="guestOS">
+                  <f:select name="guestOS" default="unix">
+                    <f:option value="unix">Unix</f:option>
+                    <f:option value="win">Prepared Windows</f:option>
+                  </f:select>
+                </f:entry>
+                <f:entry title="Guest OS startup timeout (seconds)." field="guestOsStartupTimeout">
+                  <f:textbox default="60"/>
+                </f:entry>
+           </f:advanced>
       </f:section>
 
       <f:section title="CloudStack Options">
@@ -166,6 +171,7 @@
       </f:section>
       
     </f:advanced>
+  
     <f:entry title="">
       <div align="right">
         <f:repeatableDeleteButton/>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -134,6 +134,13 @@
           <f:checkbox />
         </f:entry>
 
+        <f:entry title="Guest OS" field="guestOS">
+          <f:select name="guestOS">
+            <f:option value="win">Prepared Windows</f:option>
+            <f:option value="unix">Unix</f:option>
+          </f:select>
+        </f:entry>
+
         <f:entry title="Networks" field="networks">
           <f:textbox />
         </f:entry>

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -14,7 +14,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
 		String name = "testSlave";
 		JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", null, "hardwareId", 1, 512, "osFamily", "osVersion", "locationId",
 				"jclouds-slave-type1 jclouds-type2", "Description", "initScript", null, "1", false, null, null, true, "jenkins", null, false, null, false,
-				false, 5, 0, true, "jenkins", true, "network1_id,network2_id", "security_group1,security_group2");
+				false, 5, 0, true, "jenkins", true, "network1_id,network2_id", "security_group1,security_group2", JCloudsSlave.GuestOS.JNLP_WINDOWS.getShortName());
 
 		List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
 		templates.add(originalTemplate);

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -14,7 +14,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
 		String name = "testSlave";
 		JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", null, "hardwareId", 1, 512, "osFamily", "osVersion", "locationId",
 				"jclouds-slave-type1 jclouds-type2", "Description", "initScript", null, "1", false, null, null, true, "jenkins", null, false, null, false,
-				false, 5, 0, true, "jenkins", true, "network1_id,network2_id", "security_group1,security_group2", JCloudsSlave.GuestOS.JNLP_WINDOWS.getShortName());
+				false, 5, 0, true, "jenkins", true, "network1_id,network2_id", "security_group1,security_group2", JCloudsSlave.GuestOS.JNLP_WINDOWS.getShortName(), 60);
 
 		List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
 		templates.add(originalTemplate);


### PR DESCRIPTION
These changes add possibility to start pre-configured auto-login Windows slaves in "hybrid ssh-jnlp mode", which in its turn allows to use this Windows slaves for testing of GUI applications (everything will be started in the same session and visible if the need will arise).

By "hybrid ssh-jnlp mode" following is meant:
- slave.jar and agent-launcher.bat are copied to Windows slave over ssh.
- special autostart script triggers agent-launcher.bat as soon as it appears and launches slave.jar in jnlp mode.

To be preconfigured Windows image/snapshot needs:
- auto-login turned on.
- cygwin installer + ssh configured and started.
- /cygdrive/c/start folder created.
- special autostart script of roughly following content:
```dos
"hybrid SSH-JNLP mode"set WAIT_TIMEOUT=180 
set /a "COUNTER=0"

:WHILE_FILE_NOT_EXISTS
if not exist "C:\start\agent-launcher.bat" (
    REM If you are here, then file is missing.
    if %COUNTER% gtr %WAIT_TIMEOUT% (
        echo "agent-launcher.bat file didn't appear withing %WAIT_TIMEOUT% seconds."
        exit /B 1
    )
    REM Sleep for 5 seconds
    echo "%COUNTER% seconds had passed, but launcher script wasn't copied yet. Will check in 5 seconods..."
    timeout /t 5 /nobreak > NUL
    set /a "COUNTER+=5" REM Для более старых версий Windows (<= Windows Vista), необходимо использовать не timeout а костыль с пингом: ping -n 5 127.0.0.1 > NUL
    goto :WHILE_FILE_NOT_EXISTS
)

echo "Launcher script finally appeared, launching it..."
cd "C:\start"
start agent-launcher.bat
```