### PR TITLE
[JENKINS-25110] Update Jclouds to 1.8.0

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -318,7 +318,7 @@ public class JCloudsCloud extends Cloud {
 		}
 
 		public FormValidation doTestConnection(@QueryParameter String providerName, @QueryParameter String identity, @QueryParameter String credential,
-				@QueryParameter String privateKey, @QueryParameter String endPointUrl, @QueryParameter String zones) {
+				@QueryParameter String privateKey, @QueryParameter String endPointUrl, @QueryParameter String zones) throws IOException {
 			if (identity == null)
 				return FormValidation.error("Invalid (AccessId).");
 			if (credential == null)
@@ -347,7 +347,7 @@ public class JCloudsCloud extends Cloud {
 			} catch (Exception ex) {
 				result = FormValidation.error("Cannot connect to specified cloud, please check the identity and credentials: " + ex.getMessage());
 			} finally {
-				Closeables.closeQuietly(ctx);
+				Closeables.close(ctx,true);
 			}
 			return result;
 		}

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudInsideJenkinsLiveTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudInsideJenkinsLiveTest.java
@@ -2,6 +2,7 @@ package jenkins.plugins.jclouds.compute;
 
 import hudson.util.FormValidation;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -27,7 +28,7 @@ public class JCloudsCloudInsideJenkinsLiveTest extends HudsonTestCase {
 				Collections.<JCloudsSlaveTemplate> emptyList());
 	}
 
-	public void testDoTestConnectionCorrectCredentialsEtc() {
+	public void testDoTestConnectionCorrectCredentialsEtc () throws IOException {
 		FormValidation result = new JCloudsCloud.DescriptorImpl().doTestConnection(fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
 				generatedKeys.get("private"), fixture.getEndpoint(), null);
 		assertEquals("Connection succeeded!", result.getMessage());

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudLiveTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudLiveTest.java
@@ -2,6 +2,7 @@ package jenkins.plugins.jclouds.compute;
 
 import hudson.util.FormValidation;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 
@@ -28,7 +29,7 @@ public class JCloudsCloudLiveTest extends TestCase {
 				Collections.<JCloudsSlaveTemplate> emptyList());
 	}
 
-	public void testDoTestConnectionCorrectCredentialsEtc() {
+	public void testDoTestConnectionCorrectCredentialsEtc() throws IOException {
 		FormValidation result = new JCloudsCloud.DescriptorImpl().doTestConnection(fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
 				generatedKeys.get("private"), fixture.getEndpoint(), null);
 		assertEquals("Connection succeeded!", result.getMessage());

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <test.jenkins.blobstore.build-version />
         <test.jenkins.blobstore.identity>FIXME_IDENTITY</test.jenkins.blobstore.identity>
         <test.jenkins.blobstore.credential>FIXME_CREDENTIALS</test.jenkins.blobstore.credential>
-        <jclouds.version>1.7.3</jclouds.version>
-        <guava.version>15.0</guava.version>
+        <jclouds.version>1.8.0</jclouds.version>
+        <guava.version>18.0</guava.version>
         <jsch.version>0.1.48</jsch.version>
         <stapler.version>1.207</stapler.version>
         <hpi.plugin.version>1.97</hpi.plugin.version>


### PR DESCRIPTION
This commit updates Jclouds plugin to use
Jclouds 1.8.0 and Guava 18.0.

Fixed CloseQuitely(), which is deprecated/removed
in Guava 18.0.
