### PR TITLE
Avoid NPE in "JClouds slave cleanup thread"

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
@@ -59,6 +59,10 @@ public class JCloudsComputer extends AbstractCloudComputer<JCloudsSlave> {
     public void deleteSlave() throws IOException, InterruptedException {
         LOGGER.info("Terminating " + getName() + " slave");
         JCloudsSlave slave = getNode();
+
+        // Slave already deleted
+        if (slave == null) return;
+
         if (slave.getChannel() != null) {
             slave.getChannel().close();
         }


### PR DESCRIPTION
```
INFO: Terminating slave-name slave
Exception in thread "JClouds slave cleanup thread" java.lang.NullPointerException
        at jenkins.plugins.jclouds.compute.JCloudsComputer.deleteSlave(JCloudsComputer.java:62)
        at jenkins.plugins.jclouds.compute.JCloudsCleanupThread.execute(JCloudsCleanupThread.java:69)
        at hudson.model.AsyncPeriodicWork$1.run(AsyncPeriodicWork.java:54)
        at java.lang.Thread.run(Thread.java:745)
```
