### PR TITLE
[JENKINS-26083] Fix floating ip bug on openstack

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -270,6 +270,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         if (assignFloatingIp && options instanceof NovaTemplateOptions) {
             LOGGER.info("Setting autoAssignFloatingIp to true");
             options.as(NovaTemplateOptions.class).autoAssignFloatingIp(true);
+            options.as(NovaTemplateOptions.class).shouldAutoAssignFloatingIp();
         }
 
         if (!Strings.isNullOrEmpty((keyPairName)) && options instanceof NovaTemplateOptions) {


### PR DESCRIPTION
Previously, setting autoAssingFloatingIp option to true
threw a NullPointerException.
Calling the method shouldAutoAssignFloatingIp() seems to fixes
this problem.