### PR TITLE
[JENKINS-22587] JClouds does not honor security group against OpenStack

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -264,7 +264,12 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
         if (!Strings.isNullOrEmpty(securityGroups)) {
             LOGGER.info("Setting security groups to " + securityGroups);
-            options.securityGroups(csvToArray(securityGroups));
+            String[] securityGroupsArray = csvToArray(securityGroups);
+            options.securityGroups(securityGroupsArray);
+
+            if (options instanceof NovaTemplateOptions) {
+              options.as(NovaTemplateOptions.class).securityGroupNames(securityGroupsArray);
+            }
         }
 
         if (assignFloatingIp && options instanceof NovaTemplateOptions) {


### PR DESCRIPTION
fixes JENKINS-22587.

`NovaTemplateOptions` class has its own `securityGroupNames` field. Other services use this field when operate with instance of `NovaTemplateOptions`.
So I set this field when `templateOptions` object is an instance of `NovaTemplateOptions`.