### PR TITLE
Update to jclouds 1.9.1 and hpi-plugin 1.114

### DIFF
--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -126,10 +126,6 @@
                         <goals>
                             <goal>testCompile</goal>
                         </goals>
-                        <configuration>
-                            <source>1.7</source>
-                            <target>1.7</target>
-                        </configuration>
                     </execution>
                     <execution>
                         <id>default-compile</id>
@@ -137,13 +133,11 @@
                         <goals>
                             <goal>compile</goal>
                         </goals>
-                        <configuration>
-                            <source>1.7</source>
-                            <target>1.7</target>
-                        </configuration>
                     </execution>
                 </executions>
                 <configuration>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
                     <source>1.7</source>
                     <target>1.7</target>
                 </configuration>

--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -84,6 +84,7 @@
                         </dependency>
                     </dependencies>
                     <configuration>
+                        <disabledTestInjection>true</disabledTestInjection>
                         <dependentWarExcludes>org.apache.jclouds*,com.google.guava*</dependentWarExcludes>
                         <archive>
                             <manifestEntries>
@@ -177,6 +178,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <systemPropertyVariables>
+                        <underSurefireTest>true</underSurefireTest>
+                    </systemPropertyVariables>
                     <excludes>
                         <exclude>**/*LiveTest.java</exclude>
                     </excludes>

--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -71,7 +71,6 @@
                     <groupId>org.jenkins-ci.tools</groupId>
                     <artifactId>maven-hpi-plugin</artifactId>
                     <version>${hpi.plugin.version}</version>
-
                     <dependencies>
                         <dependency>
                             <groupId>com.google.guava</groupId>
@@ -85,7 +84,6 @@
                         </dependency>
                     </dependencies>
                     <configuration>
-                        <disabledTestInjection>true</disabledTestInjection>
                         <dependentWarExcludes>org.apache.jclouds*,com.google.guava*</dependentWarExcludes>
                         <archive>
                             <manifestEntries>
@@ -181,7 +179,6 @@
                 <configuration>
                     <excludes>
                         <exclude>**/*LiveTest.java</exclude>
-                        <exclude>**/*JCloudsSlaveTemplateTest.java</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/jclouds-plugin/src/main/resources/index.jelly
+++ b/jclouds-plugin/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     Allows Jenkins to build using Cloud Servers via JClouds.
 </div>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStoreEntry/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStoreEntry/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="Source" field="sourceFile">
         <f:textbox/>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStorePublisher/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStorePublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
 
     <f:entry title="JClouds Cloud Storage profile" field="profileName">

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStorePublisher/global.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStorePublisher/global.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
     <!-- nothing to configure -->

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
   <f:entry title="Cloud Name" field="cloudName">

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/help-suspendOrTerminate.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/help-suspendOrTerminate.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
   If selected, when the build finishes, suspend the instances rather than terminate them.
 </div>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core"
          xmlns:f="/lib/form">
   <f:entry field="instancesToRun">

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/computerSet.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/computerSet.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler"
          xmlns:f="/lib/form">
     <j:if test="${it.hasPermission(it.PROVISION)}">

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:st="jelly:stapler">
     <f:entry title="Profile" field="profile">
         <f:textbox/>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsComputer/configure.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsComputer/configure.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout norefresh="true" permission="${app.ADMINISTER}" title="${it.name} Configuration">
         <st:include page="sidepanel.jelly"/>

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
@@ -41,7 +41,10 @@ public class JCloudsCloudTest {
         WebAssert.assertInputPresent(page2, "_.instanceCap");
         WebAssert.assertInputPresent(page2, "_.retentionTime");
         // WebAssert does not recognize select as input ?!
-        //WebAssert.assertInputPresent(page2, "_.cloudGlobalKeyId");
+        // WebAssert.assertSelectPresent(page2, "_.cloudGlobalKeyId");
+        WebAssert.assertInputPresent(page2, "_.scriptTimeout");
+        WebAssert.assertInputPresent(page2, "_.startTimeout");
+        WebAssert.assertInputPresent(page2, "_.zones");
 
         HtmlForm configForm2 = page2.getFormByName("config");
         HtmlButton testConnectionButton = configForm2.getButtonByCaption("Test Connection");
@@ -54,8 +57,9 @@ public class JCloudsCloudTest {
     @Test
     public void testConfigRoundtrip() throws Exception {
 
-        JCloudsCloud original = new JCloudsCloud("aws-profile", "aws-ec2", "identity", "credential", "", "endPointUrl", 1,
-                CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList());
+        JCloudsCloud original = new JCloudsCloud("aws-profile", "aws-ec2", "identity",
+                "credential", "", "http://localhost", 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
+                600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList());
 
         j.getInstance().clouds.add(original);
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));

--- a/pom.xml
+++ b/pom.xml
@@ -29,11 +29,11 @@
         <test.jenkins.blobstore.build-version />
         <test.jenkins.blobstore.identity>FIXME_IDENTITY</test.jenkins.blobstore.identity>
         <test.jenkins.blobstore.credential>FIXME_CREDENTIALS</test.jenkins.blobstore.credential>
-        <jclouds.version>1.8.1</jclouds.version>
+        <jclouds.version>1.9.1</jclouds.version>
         <guava.version>18.0</guava.version>
         <jsch.version>0.1.48</jsch.version>
         <stapler.version>1.207</stapler.version>
-        <hpi.plugin.version>1.106</hpi.plugin.version>
+        <hpi.plugin.version>1.114</hpi.plugin.version>
         <jsr305.version>1.3.9</jsr305.version>
         <jenkins.parent.version>${project.parent.version}</jenkins.parent.version>
     </properties>


### PR DESCRIPTION
* Updates jclouds and the maven-hpi-plugin to their latest stable versions.
* Fixes (and reactivate) some tests.
* Fixes of jelly files for preventing possible XSS attacks.
* Increases compiler verbosity (show warnings and deprecations).