### PR TITLE
Credentials migration, next step

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -64,19 +64,17 @@ import shaded.com.google.common.collect.Iterables;
 import shaded.com.google.common.io.Closeables;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
-import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.BasicSSHUserPrivateKey;
-import org.acegisecurity.context.SecurityContext;
 import hudson.security.ACL;
-import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import org.acegisecurity.context.SecurityContextHolder;
 import hudson.security.AccessControlled;
 
+import jenkins.plugins.jclouds.internal.CredentialsHelper;
 import jenkins.plugins.jclouds.internal.SSHPublicKeyExtractor;
 
 import hudson.util.XStream2;
@@ -91,8 +89,11 @@ public class JCloudsCloud extends Cloud {
 
     static final Logger LOGGER = Logger.getLogger(JCloudsCloud.class.getName());
 
-    public final String identity;
-    public final Secret credential;
+    /** @deprecated Not used anymore, but retained for backward compatibility during deserialization. */
+    private final transient String identity;
+    /** @deprecated Not used anymore, but retained for backward compatibility during deserialization. */
+    private final transient Secret credential;
+
     public final String providerName;
 
     /** @deprecated Not used anymore, but retained for backward compatibility during deserialization. */
@@ -111,6 +112,7 @@ public class JCloudsCloud extends Cloud {
     public final String zones;
 
     private String cloudGlobalKeyId;
+    private String cloudCredentialsId;
 
     public static List<String> getCloudNames() {
         List<String> cloudNames = new ArrayList<String>();
@@ -127,6 +129,14 @@ public class JCloudsCloud extends Cloud {
         return (JCloudsCloud) Jenkins.getActiveInstance().clouds.getByName(name);
     }
 
+    public String getCloudCredentialsId() {
+        return cloudCredentialsId;
+    }
+
+    public void setCloudCredentialsId(final String value) {
+        cloudCredentialsId = value;
+    }
+
     public String getCloudGlobalKeyId() {
         return cloudGlobalKeyId;
     }
@@ -136,39 +146,49 @@ public class JCloudsCloud extends Cloud {
     }
 
     public String getGlobalPrivateKey() {
-        if (Strings.isNullOrEmpty(cloudGlobalKeyId)) {
-            return "";
-        }
-        SSHUserPrivateKey supk = CredentialsMatchers.firstOrNull(
-                CredentialsProvider.lookupCredentials(SSHUserPrivateKey.class, Hudson.getInstance(), ACL.SYSTEM, null),
-                CredentialsMatchers.withId(cloudGlobalKeyId));
-        if (null != supk) {
-            return supk.getPrivateKey();
+        return getPrivateKeyFromCredential(cloudGlobalKeyId);
+    }
+
+    public String getGlobalPublicKey() {
+        return getPublicKeyFromCredential(cloudGlobalKeyId);
+    }
+
+    private String getPrivateKeyFromCredential(final String id) {
+        if (!Strings.isNullOrEmpty(id)) {
+            SSHUserPrivateKey supk = CredentialsMatchers.firstOrNull(
+                    CredentialsProvider.lookupCredentials(SSHUserPrivateKey.class, Hudson.getInstance(), ACL.SYSTEM, null),
+                    CredentialsMatchers.withId(id));
+            if (null != supk) {
+                return supk.getPrivateKey();
+            }
         }
         return "";
     }
 
-    public String getGlobalPublicKey() {
-        try {
-            return SSHPublicKeyExtractor.extract(getGlobalPrivateKey(), null);
-        } catch (IOException e) {
-            LOGGER.warning(String.format("Error while extracting public key: %s", e));
+    private String getPublicKeyFromCredential(final String id) {
+        if (!Strings.isNullOrEmpty(id)) {
+            try {
+                return SSHPublicKeyExtractor.extract(getPrivateKeyFromCredential(id), null);
+            } catch (IOException e) {
+                LOGGER.warning(String.format("Error while extracting public key: %s", e));
+            }
         }
         return "";
     }
 
     @DataBoundConstructor
-    public JCloudsCloud(final String profile, final String providerName, final String identity, final String credential, final String cloudGlobalKeyId,
+    public JCloudsCloud(final String profile, final String providerName, final String cloudCredentialsId, final String cloudGlobalKeyId,
             final String endPointUrl, final int instanceCap, final int retentionTime, final int scriptTimeout, final int startTimeout,
             final String zones, final List<JCloudsSlaveTemplate> templates) {
         super(Util.fixEmptyAndTrim(profile));
         this.profile = Util.fixEmptyAndTrim(profile);
         this.providerName = Util.fixEmptyAndTrim(providerName);
-        this.identity = Util.fixEmptyAndTrim(identity);
-        this.credential = Secret.fromString(credential);
+        this.identity = null; // Not used anymore, but retained for backward compatibility.
+        this.credential = null; // Not used anymore, but retained for backward compatibility.
         this.privateKey = null; // Not used anymore, but retained for backward compatibility.
         this.publicKey = null; // Not used anymore, but retained for backward compatibility.
         this.cloudGlobalKeyId = Util.fixEmptyAndTrim(cloudGlobalKeyId);
+        this.cloudCredentialsId = Util.fixEmptyAndTrim(cloudCredentialsId);
         this.endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
         this.instanceCap = instanceCap;
         this.retentionTime = retentionTime;
@@ -219,6 +239,15 @@ public class JCloudsCloud extends Cloud {
             .buildView(ComputeServiceContext.class);
     }
 
+    static ComputeServiceContext ctx(final String providerName, final String credentialsId, final Properties overrides, final String zones) {
+        StandardUsernameCredentials u = CredentialsHelper.getCredentialsById(credentialsId);
+        if (null != u && u instanceof StandardUsernamePasswordCredentials) {
+            StandardUsernamePasswordCredentials up = (StandardUsernamePasswordCredentials)u;
+            return ctx(providerName, up.getUsername(), up.getPassword().toString(), overrides, zones);
+        }
+        throw new RuntimeException("Using keys as credential for google cloud is not (yet) supported");
+    }
+
     public ComputeService newCompute() {
         Properties overrides = new Properties();
         if (!Strings.isNullOrEmpty(this.endPointUrl)) {
@@ -230,7 +259,7 @@ public class JCloudsCloud extends Cloud {
         if (startTimeout > 0) {
             overrides.setProperty(ComputeServiceProperties.TIMEOUT_NODE_RUNNING, String.valueOf(startTimeout));
         }
-        return ctx(this.providerName, this.identity, Secret.toString(credential), overrides, this.zones).getComputeService();
+        return ctx(this.providerName, this.cloudCredentialsId, overrides, this.zones).getComputeService();
     }
 
     public ComputeService getCompute() {
@@ -394,20 +423,17 @@ public class JCloudsCloud extends Cloud {
             return "Cloud (JClouds)";
         }
 
-        public FormValidation doTestConnection(@QueryParameter String providerName, @QueryParameter String identity, @QueryParameter String credential,
-                @QueryParameter String cloudGlobalKeyId, @QueryParameter String endPointUrl, @QueryParameter String zones)  throws IOException {
-            if (identity == null)
-                return FormValidation.error("Invalid (AccessId).");
-            if (credential == null)
-                return FormValidation.error("Invalid credential (secret key).");
+        public FormValidation doTestConnection(@QueryParameter String providerName, @QueryParameter String cloudCredentialsId,
+                @QueryParameter String cloudGlobalKeyId, @QueryParameter String endPointUrl, @QueryParameter String zones) throws IOException {
+            if (null == Util.fixEmptyAndTrim(cloudCredentialsId)) {
+                return FormValidation.error("Cloud credentials not specified.");
+            }
             if (null == Util.fixEmptyAndTrim(cloudGlobalKeyId)) {
                 return FormValidation.error("Cloud RSA key is not specified.");
             }
 
             // Remove empty text/whitespace from the fields.
             providerName = Util.fixEmptyAndTrim(providerName);
-            identity = Util.fixEmptyAndTrim(identity);
-            credential = Secret.fromString(credential).getPlainText();
             endPointUrl = Util.fixEmptyAndTrim(endPointUrl);
             zones = Util.fixEmptyAndTrim(zones);
 
@@ -419,11 +445,11 @@ public class JCloudsCloud extends Cloud {
                     overrides.setProperty(Constants.PROPERTY_ENDPOINT, endPointUrl);
                 }
 
-                ctx = ctx(providerName, identity, credential, overrides, zones);
+                ctx = ctx(providerName, cloudCredentialsId, overrides, zones);
 
                 ctx.getComputeService().listNodes();
             } catch (Exception ex) {
-                result = FormValidation.error("Cannot connect to specified cloud, please check the identity and credentials: " + ex.getMessage());
+                result = FormValidation.error("Cannot connect to specified cloud, please check the credentials: " + ex.getMessage());
             } finally {
                 Closeables.close(ctx,true);
             }
@@ -450,6 +476,14 @@ public class JCloudsCloud extends Cloud {
                 m.add(supportedProvider, supportedProvider);
             }
             return m;
+        }
+
+        public ListBoxModel  doFillCloudCredentialsIdItems(@AncestorInPath ItemGroup context) {
+            if (!(context instanceof AccessControlled ? (AccessControlled) context : Jenkins.getActiveInstance()).hasPermission(Computer.CONFIGURE)) {
+                return new ListBoxModel();
+            }
+            return new StandardUsernameListBoxModel().withAll(
+                    CredentialsProvider.lookupCredentials(StandardUsernameCredentials.class, context, ACL.SYSTEM, null));
         }
 
         public ListBoxModel  doFillCloudGlobalKeyIdItems(@AncestorInPath ItemGroup context) {
@@ -546,6 +580,9 @@ public class JCloudsCloud extends Cloud {
             if (Strings.isNullOrEmpty(c.getCloudGlobalKeyId()) && !Strings.isNullOrEmpty(c.privateKey)) {
                 c.setCloudGlobalKeyId(convertCloudPrivateKey(c.name, c.privateKey));
             }
+            if (Strings.isNullOrEmpty(c.getCloudCredentialsId()) && !Strings.isNullOrEmpty(c.identity)) {
+                c.setCloudCredentialsId(CredentialsHelper.convertCloudCredentials(c.name, c.identity, c.credential));
+            }
             for (JCloudsSlaveTemplate t : c.templates) {
                 t.upgrade();
             }
@@ -563,18 +600,11 @@ public class JCloudsCloud extends Cloud {
             StandardUsernameCredentials u =
                 new BasicSSHUserPrivateKey(CredentialsScope.SYSTEM, null, "Global key",
                         new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(privateKey), null, description);
-            final SecurityContext previousContext = ACL.impersonate(ACL.SYSTEM);
             try {
-                CredentialsStore s = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
-                try {
-                    s.addCredentials(Domain.global(), u);
-                    return u.getId();
-                } catch (IOException e) {
-                    LOGGER.warning(String.format("Error while migrating privateKey: %s", e.getMessage()));
-                }
-            } finally {
-                SecurityContextHolder.setContext(previousContext);
-            }
+                return CredentialsHelper.storeCredentials(u);
+            } catch (IOException e) {
+                LOGGER.warning(String.format("Error while migrating privateKey: %s", e.getMessage()));
+            } 
             return null;
         }
 

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -221,15 +221,8 @@ public class JCloudsCloud extends Cloud {
         }
     }, new EnterpriseConfigurationModule());
 
-    static ComputeServiceContext ctx(String providerName, String identity, String credential, String endPointUrl, String zones) {
-        Properties overrides = new Properties();
-        if (!Strings.isNullOrEmpty(endPointUrl)) {
-            overrides.setProperty(Constants.PROPERTY_ENDPOINT, endPointUrl);
-        }
-        return ctx(providerName, identity, credential, overrides, zones);
-    }
-
-    static ComputeServiceContext ctx(String providerName, String identity, String credential, Properties overrides, String zones) {
+    private static ComputeServiceContext ctx(final String providerName, final String identity, final String credential,
+            final Properties overrides, final String zones) {
         if (!Strings.isNullOrEmpty(zones)) {
             overrides.setProperty(LocationConstants.PROPERTY_ZONES, zones);
         }
@@ -239,13 +232,21 @@ public class JCloudsCloud extends Cloud {
             .buildView(ComputeServiceContext.class);
     }
 
-    static ComputeServiceContext ctx(final String providerName, final String credentialsId, final Properties overrides, final String zones) {
+    private static ComputeServiceContext ctx(final String providerName, final String credentialsId, final Properties overrides, final String zones) {
         StandardUsernameCredentials u = CredentialsHelper.getCredentialsById(credentialsId);
         if (null != u && u instanceof StandardUsernamePasswordCredentials) {
             StandardUsernamePasswordCredentials up = (StandardUsernamePasswordCredentials)u;
             return ctx(providerName, up.getUsername(), up.getPassword().toString(), overrides, zones);
         }
         throw new RuntimeException("Using keys as credential for google cloud is not (yet) supported");
+    }
+
+    static ComputeServiceContext ctx(final String providerName, final String credentialsId, final String endPointUrl, final String zones) {
+        final Properties overrides = new Properties();
+        if (!Strings.isNullOrEmpty(endPointUrl)) {
+            overrides.setProperty(Constants.PROPERTY_ENDPOINT, endPointUrl);
+        }
+        return ctx(providerName, credentialsId, overrides, zones);
     }
 
     public ComputeService newCompute() {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -686,10 +686,9 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             return false;
         }
 
-        public ListBoxModel doFillHardwareIdItems(@RelativePath("..") @QueryParameter String providerName,
-                @RelativePath("..") @QueryParameter String cloudCredentialsId,
-                @RelativePath("..") @QueryParameter String endPointUrl,
-                @RelativePath("..") @QueryParameter String zones) {
+        public ListBoxModel doFillHardwareIdItems(
+                @RelativePath("..") @QueryParameter String providerName, @RelativePath("..") @QueryParameter String cloudCredentialsId,
+                @RelativePath("..") @QueryParameter String endPointUrl, @RelativePath("..") @QueryParameter String zones) {
 
             ListBoxModel m = new ListBoxModel();
             if (prepareListBoxModel(providerName, cloudCredentialsId, endPointUrl, zones, m)) {
@@ -764,10 +763,8 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         }
 
         public ListBoxModel doFillLocationIdItems(
-                @RelativePath("..") @QueryParameter String providerName,
-                @RelativePath("..") @QueryParameter String cloudCredentialsId,
-                @RelativePath("..") @QueryParameter String endPointUrl,
-                @RelativePath("..") @QueryParameter String zones) {
+                @RelativePath("..") @QueryParameter String providerName, @RelativePath("..") @QueryParameter String cloudCredentialsId,
+                @RelativePath("..") @QueryParameter String endPointUrl, @RelativePath("..") @QueryParameter String zones) {
 
             ListBoxModel m = new ListBoxModel();
             if (prepareListBoxModel(providerName, cloudCredentialsId, endPointUrl, zones, m)) {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/internal/CredentialsHelper.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/internal/CredentialsHelper.java
@@ -1,0 +1,86 @@
+package jenkins.plugins.jclouds.internal;
+
+import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
+import com.cloudbees.plugins.credentials.domains.Domain;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.CredentialsStore;
+import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
+
+import shaded.com.google.common.base.Strings;
+
+import hudson.plugins.sshslaves.SSHLauncher;
+import hudson.security.ACL;
+import hudson.util.Secret;
+
+import jenkins.model.Jenkins;
+
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+/**
+ * Helper for dealing with credentials.
+ * @author Fritz Elfert
+ */
+public final class CredentialsHelper {
+
+    static final Logger LOGGER = Logger.getLogger(CredentialsHelper.class.getName());
+
+    /**
+     * Stores a new credentials record.
+     * @param u The new credentials to store;
+     * @return The Id of the new record or {@code null} on failure.
+     * @throws IOException on error.
+     */
+    public static String storeCredentials(final StandardUsernameCredentials u) throws IOException {
+        if (null != u) {
+            final SecurityContext previousContext = ACL.impersonate(ACL.SYSTEM);
+            try {
+                final CredentialsStore s = CredentialsProvider.lookupStores(Jenkins.getInstance()).iterator().next();
+                s.addCredentials(Domain.global(), u);
+                return u.getId();
+            } finally {
+                SecurityContextHolder.setContext(previousContext);
+            }
+        }
+        return null;
+    }
+
+
+    /**
+     * Use the ssh-slaves-plugin to retrieve a credentials object by its Id.
+     *
+     * @param id The Id of the credentials object.
+     * @return The StandardUsernameCredentials or null if not found.
+     */
+    public static StandardUsernameCredentials getCredentialsById(final String id) {
+        if (Strings.isNullOrEmpty(id)) {
+            return null;
+        }
+        return SSHLauncher.lookupSystemCredentials(id);
+    }
+
+    /**
+     * Converts old identity/credential new UsernamePassword credential-plugin record.
+     * @param name The name of the JCloudsCloud.
+     * @param identity The old identity (AKA username).
+     * @param credential The old credential (AKA password).
+     * @return The Id of the newly created  credential-plugin record.
+     */
+    public static String convertCloudCredentials(final String name, final String identity, final Secret credential) {
+        final String description = "JClouds cloud " + name + " - auto-migrated";
+        StandardUsernameCredentials u = new UsernamePasswordCredentialsImpl(
+                CredentialsScope.SYSTEM, null, description, identity, Secret.toString(credential));
+        try {
+            return CredentialsHelper.storeCredentials(u);
+        } catch (IOException e) {
+            LOGGER.warning(String.format("Error while migrating identity/credentials: %s", e.getMessage()));
+        } 
+        return null;
+    }
+
+}
+

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
@@ -15,11 +15,8 @@
     <f:entry title="Retention Time" field="retentionTime">
         <f:number clazz="number" min="-1" step="1" default="30"/>
     </f:entry>
-    <f:entry title="Identity" field="identity">
-        <f:textbox/>
-    </f:entry>
-    <f:entry title="Credential" field="credential">
-        <f:password/>
+    <f:entry title="${%Credentials}" field="cloudCredentialsId">
+        <c:select/>
     </f:entry>
     <f:entry title="${%Cloud RSA key}" field="cloudGlobalKeyId">
         <c:select/>
@@ -35,7 +32,7 @@
             <f:textbox/>
         </f:entry>
     </f:advanced>
-    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="providerName,identity,credential,cloudGlobalKeyId,endPointUrl"/>
+    <f:validateButton title="Test Connection" progress="${%Testing...}" method="testConnection" with="providerName,cloudCredentialsId,cloudGlobalKeyId,endPointUrl"/>
     <f:entry title="Cloud Instance Templates" description="${%List of Cloud Instances to be launched as slaves}">
         <f:repeatable field="templates">
             <st:include page="config.jelly" class="${descriptor.clazz}"/>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-cloudCredentialsId.html
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-cloudCredentialsId.html
@@ -1,0 +1,7 @@
+<div>
+  The credentials for this cloud instance. Depending on the cloud provider,
+  this can be a username/password pair or a username/privatekey pair.
+  Furthermore, some providers require the username to be composed multiple
+  from values. (e.g: OpenStack uses <code><i>tenant</i>:<i>username</i></code>).
+</div>
+

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-credential.html
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-credential.html
@@ -1,3 +1,0 @@
-<div>
-  Cloud account's credential, sometimes called "secret key".
-</div>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-identity.html
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/help-identity.html
@@ -1,3 +1,0 @@
-<div>
-  Cloud account's identity or access key.
-</div>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -25,7 +25,7 @@
           <f:select />
         </f:entry>
         <f:validateButton title="${%Check Hardware Id}" progress="${%Checking...}" method="validateHardwareId"
-                            with="providerName,identity,credential,endPointUrl,hardwareId"/>
+                            with="providerName,cloudCredentialsId,endPointUrl,hardwareId"/>
       </f:radioBlock>
       
       <f:radioBlock inline="true" name="jclouds.useHardwareId" value="false"
@@ -48,7 +48,7 @@
         </f:entry>
         
         <f:validateButton title="${%Check Image Id}" progress="${%Checking...}" method="validateImageId"
-                          with="providerName,identity,credential,endPointUrl,imageId"/>
+                          with="providerName,cloudCredentialsId,endPointUrl,imageId"/>
       </f:radioBlock>
 
       <f:radioBlock inline="true" name="jclouds.imageSelectionOption" value="imageNameRegex"
@@ -58,7 +58,7 @@
         </f:entry>
 
         <f:validateButton title="${%Check Image Name Regex}" progress="${%Checking...}" method="validateImageNameRegex"
-                          with="providerName,identity,credential,endPointUrl,imageNameRegex"/>
+                          with="providerName,cloudCredentialsId,endPointUrl,imageNameRegex"/>
       </f:radioBlock>
 
       <f:radioBlock inline="true" name="jclouds.imageSelectionOption" value="osFamilyAndVersion"
@@ -79,7 +79,7 @@
           <f:select />
         </f:entry>
         <f:validateButton title="${%Check Location Id}" progress="${%Checking...}" method="validateLocationId"
-                          with="providerName,identity,credential,endPointUrl,locationId"/>
+                          with="providerName,cloudCredentialsId,endPointUrl,locationId"/>
       </f:section>
       <f:section title="${%General Options}">
         <f:optionalBlock name="hasOverrideRetentionTime" title="${%Override Retention Time}" checked="${instance.hasOverrideRetentionTime()}" inline="true">

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/ComputeTestFixture.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/ComputeTestFixture.java
@@ -14,6 +14,10 @@ import shaded.com.google.common.base.Predicates;
 import shaded.com.google.common.collect.Maps;
 import com.google.inject.Module;
 
+import jenkins.plugins.jclouds.internal.CredentialsHelper;
+
+import hudson.util.Secret;
+
 @SuppressWarnings("unchecked")
 public class ComputeTestFixture extends BaseComputeServiceContextLiveTest {
     public static String PROVIDER;
@@ -70,12 +74,8 @@ public class ComputeTestFixture extends BaseComputeServiceContextLiveTest {
         return endpoint;
     }
 
-    public String getIdentity() {
-        return identity;
-    }
-
-    public String getCredential() {
-        return credential;
+    public String getCredentialsId() {
+        return CredentialsHelper.convertCloudCredentials(provider, identity, Secret.fromString(credential));
     }
 
     public void setUp() {

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudInsideJenkinsLiveTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudInsideJenkinsLiveTest.java
@@ -23,13 +23,13 @@ public class JCloudsCloudInsideJenkinsLiveTest extends HudsonTestCase {
         generatedKeys = SshKeys.generate();
 
         // TODO: this may need to vary per test
-        cloud = new JCloudsCloud(fixture.getProvider() + "-profile", fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
+        cloud = new JCloudsCloud(fixture.getProvider() + "-profile", fixture.getProvider(), fixture.getCredentialsId(),
                 null, fixture.getEndpoint(), 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList());
     }
 
     public void testDoTestConnectionCorrectCredentialsEtc() throws IOException {
-        FormValidation result = new JCloudsCloud.DescriptorImpl().doTestConnection(fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
+        FormValidation result = new JCloudsCloud.DescriptorImpl().doTestConnection(fixture.getProvider(), fixture.getCredentialsId(),
                 generatedKeys.get("private"), fixture.getEndpoint(), null);
         assertEquals("Connection succeeded!", result.getMessage());
     }

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudLiveTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudLiveTest.java
@@ -24,13 +24,13 @@ public class JCloudsCloudLiveTest extends TestCase {
         generatedKeys = SshKeys.generate();
 
         // TODO: this may need to vary per test
-        cloud = new JCloudsCloud(fixture.getProvider() + "-profile", fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
+        cloud = new JCloudsCloud(fixture.getProvider() + "-profile", fixture.getProvider(), fixture.getCredentialsId(),
                 null, fixture.getEndpoint(), 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES, 600 * 1000, 600 * 1000, null,
                 Collections.<JCloudsSlaveTemplate>emptyList());
     }
 
     public void testDoTestConnectionCorrectCredentialsEtc() throws IOException {
-        FormValidation result = new JCloudsCloud.DescriptorImpl().doTestConnection(fixture.getProvider(), fixture.getIdentity(), fixture.getCredential(),
+        FormValidation result = new JCloudsCloud.DescriptorImpl().doTestConnection(fixture.getProvider(), fixture.getCredentialsId(),
                 generatedKeys.get("private"), fixture.getEndpoint(), null);
         assertEquals("Connection succeeded!", result.getMessage());
     }

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsCloudTest.java
@@ -36,8 +36,8 @@ public class JCloudsCloudTest {
         HtmlPage page2 = page.getAnchorByText("Cloud (JClouds)").click();
         WebAssert.assertInputPresent(page2, "_.profile");
         WebAssert.assertInputPresent(page2, "_.endPointUrl");
-        WebAssert.assertInputPresent(page2, "_.identity");
-        WebAssert.assertInputPresent(page2, "_.credential");
+        // WebAssert does not recognize select as input ?!
+        // WebAssert.assertInputPresent(page2, "_.cloudCredentialsId");
         WebAssert.assertInputPresent(page2, "_.instanceCap");
         WebAssert.assertInputPresent(page2, "_.retentionTime");
         // WebAssert does not recognize select as input ?!
@@ -57,18 +57,18 @@ public class JCloudsCloudTest {
     @Test
     public void testConfigRoundtrip() throws Exception {
 
-        JCloudsCloud original = new JCloudsCloud("aws-profile", "aws-ec2", "identity",
-                "credential", "", "http://localhost", 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
+        JCloudsCloud original = new JCloudsCloud("aws-profile", "aws-ec2", "",
+                "", "http://localhost", 1, CloudInstanceDefaults.DEFAULT_INSTANCE_RETENTION_TIME_IN_MINUTES,
                 600 * 1000, 600 * 1000, null, Collections.<JCloudsSlaveTemplate>emptyList());
 
         j.getInstance().clouds.add(original);
         j.submit(j.createWebClient().goTo("configure").getFormByName("config"));
 
         j.assertEqualBeans(original, j.getInstance().clouds.getByName("aws-profile"),
-                "profile,providerName,identity,credential,cloudGlobalKeyId,endPointUrl,instanceCap,retentionTime");
+                "profile,providerName,cloudCredentialsId,cloudGlobalKeyId,endPointUrl,instanceCap,retentionTime");
 
         j.assertEqualBeans(original, JCloudsCloud.getByName("aws-profile"),
-                "profile,providerName,identity,credential,cloudGlobalKeyId,endPointUrl,instanceCap,retentionTime");
+                "profile,providerName,cloudCredentialsId,cloudGlobalKeyId,endPointUrl,instanceCap,retentionTime");
     }
 
 }

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -31,7 +31,7 @@ public class JCloudsSlaveTemplateTest {
         templates.add(beforeTemplate);
 
         final JCloudsCloud beforeCloud = new JCloudsCloud("aws-profile",
-                "aws-ec2", "identity", "credential", "cloudGlobalKeyId",
+                "aws-ec2", "cloudCredentialsId", "cloudGlobalKeyId",
                 "http://localhost", 1, 30, 600 * 1000, 600 * 1000, null, templates);
 
         j.jenkins.clouds.add(beforeCloud);
@@ -41,7 +41,7 @@ public class JCloudsSlaveTemplateTest {
         final JCloudsSlaveTemplate afterTemplate = afterCloud.getTemplate(name);
 
         j.assertEqualBeans(beforeCloud, afterCloud,
-                "profile,providerName,identity,credential,endPointUrl");
+                "profile,providerName,endPointUrl");
         j.assertEqualBeans(beforeTemplate, afterTemplate,
                 "name,cores,ram,osFamily,osVersion,labelString,description,initScript,numExecutors,stopOnTerminate,mode");
     }


### PR DESCRIPTION
This one converts the old identity/credential pair into a Credentals object. (as usual: fully backwards compatible wit auto-migration).
This could also potentially solve the multiline requirement from #87 , but I need feedback on the exact key format before I can enable that.