### PR TITLE
Upgrade to DigitalOcean v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ release.properties
 **/dependency-reduced-pom.xml
 **/target
 .DS_Store
+.java-version

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -32,7 +32,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.jclouds.labs</groupId>
-            <artifactId>digitalocean</artifactId>
+            <artifactId>digitalocean2</artifactId>
             <version>${jclouds.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
DigitalOcean API v1 will sunset in a few days: https://developers.digitalocean.com/documentation/changelog/api-v1/sunsetting-api-v1/

This PR changes the provider to use the version 2 of the api. However, this will break any existing configuration that uses the v1 provider as the credentials have changed. Users will have to generate an OAuth token in the DigitalOcean console and update the credentials accordingly (the v2 does not support the old clientid/apikey authentication).