### PR TITLE
Address copying and executing slave.jar on Windows Slave

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
@@ -37,13 +37,14 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	private final String privateKey;
 	private final boolean authSudo;
 	private final String jvmOptions;
+	private final boolean isWindows;
 
 	@DataBoundConstructor
 	@SuppressWarnings("rawtypes")
 	public JCloudsSlave(String cloudName, String name, String nodeDescription, String remoteFS, String numExecutors, Mode mode, String labelString,
 			ComputerLauncher launcher, RetentionStrategy retentionStrategy, List<? extends NodeProperty<?>> nodeProperties, boolean stopOnTerminate,
-			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo, String jvmOptions) throws Descriptor.FormException,
-			IOException {
+			int overrideRetentionTime, String user, String password, String privateKey, boolean authSudo, String jvmOptions, boolean isWindows)
+			throws Descriptor.FormException, IOException {
 		super(name, nodeDescription, remoteFS, numExecutors, mode, labelString, launcher, retentionStrategy, nodeProperties);
 		this.stopOnTerminate = stopOnTerminate;
 		this.cloudName = cloudName;
@@ -53,6 +54,7 @@ public class JCloudsSlave extends AbstractCloudSlave {
 		this.privateKey = privateKey;
 		this.authSudo = authSudo;
 		this.jvmOptions = jvmOptions;
+		this.isWindows = isWindows;
 	}
 
 	/**
@@ -74,16 +76,18 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	 *            - if true, suspend the slave rather than terminating it.
 	 * @param overrideRetentionTime
 	 *            - Retention time to use specifically for this slave, overriding the cloud default.
+	 * @param isWindows
+	 *            - True if slave is Windows; false otherwise
 	 * @throws IOException
 	 * @throws Descriptor.FormException
 	 */
 	public JCloudsSlave(final String cloudName, final String fsRoot, NodeMetadata metadata, final String labelString, final String description,
-			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime, String jvmOptions) throws IOException,
-			Descriptor.FormException {
+			final String numExecutors, final boolean stopOnTerminate, final int overrideRetentionTime, String jvmOptions, boolean isWindows)
+			throws IOException, Descriptor.FormException {
 		this(cloudName, metadata.getName(), description, fsRoot, numExecutors, Mode.EXCLUSIVE, labelString, new JCloudsLauncher(),
 				new JCloudsRetentionStrategy(), Collections.<NodeProperty<?>> emptyList(), stopOnTerminate, overrideRetentionTime, metadata.getCredentials()
 						.getUser(), metadata.getCredentials().getPassword(), metadata.getCredentials().getPrivateKey(), metadata.getCredentials()
-						.shouldAuthenticateSudo(), jvmOptions);
+						.shouldAuthenticateSudo(), jvmOptions, isWindows);
 		this.nodeMetaData = metadata;
 		this.nodeId = nodeMetaData.getId();
 	}
@@ -144,6 +148,13 @@ public class JCloudsSlave extends AbstractCloudSlave {
 	 */
 	public String getCloudName() {
 		return cloudName;
+	}
+
+	/**
+	 * Get the flag for determining if the slave is a Windows machine
+	 */
+	public boolean isWindows() {
+		return isWindows;
 	}
 
 	public boolean isPendingDelete() {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -96,6 +96,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 	public final boolean assignPublicIp;
         public final String networks;
         public final String securityGroups;
+	public final boolean isWindows;
 
 	private transient Set<LabelAtom> labelSet;
 
@@ -107,7 +108,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 			final String initScript, final String userData, final String numExecutors, final boolean stopOnTerminate, final String vmPassword, final String vmUser,
 			final boolean preInstalledJava, final String jvmOptions, final String jenkinsUser, final boolean preExistingJenkinsUser, final String fsRoot,
 			final boolean allowSudo, final boolean installPrivateKey, final int overrideRetentionTime, final int spoolDelayMs, final boolean assignFloatingIp,
-			final String keyPairName, final boolean assignPublicIp, final String networks, final String securityGroups) {
+			final String keyPairName, final boolean assignPublicIp, final String networks, final String securityGroups, final boolean isWindows) {
 
 		this.name = Util.fixEmptyAndTrim(name);
 		this.imageId = Util.fixEmptyAndTrim(imageId);
@@ -140,6 +141,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 		this.assignPublicIp = assignPublicIp;
                 this.networks = networks;
                 this.securityGroups = securityGroups;
+		this.isWindows = isWindows;
 		readResolve();
 	}
 
@@ -192,7 +194,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
 
 		try {
 			return new JCloudsSlave(getCloud().getDisplayName(), getFsRoot(), nodeMetadata, labelString, description, numExecutors, stopOnTerminate,
-					overrideRetentionTime, getJvmOptions());
+					overrideRetentionTime, getJvmOptions(), isWindows);
 		} catch (Descriptor.FormException e) {
 			throw new AssertionError("Invalid configuration " + e.getMessage());
 		}

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -141,6 +141,10 @@
         <f:entry title="Security Groups" field="securityGroups">
           <f:textbox />
         </f:entry>
+
+        <f:entry title="${%Is Windows Image}" field="isWindows">
+          <f:checkbox />
+        </f:entry>
       </f:section>
       
       <f:section title="Open Stack Options">
@@ -157,7 +161,7 @@
           <f:checkbox default="true"/>
         </f:entry>
       </f:section>
-      
+
     </f:advanced>
     <f:entry title="">
       <div align="right">

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -14,7 +14,7 @@ public class JCloudsSlaveTemplateTest extends HudsonTestCase {
 		String name = "testSlave";
 		JCloudsSlaveTemplate originalTemplate = new JCloudsSlaveTemplate(name, "imageId", null, "hardwareId", 1, 512, "osFamily", "osVersion", "locationId",
 				"jclouds-slave-type1 jclouds-type2", "Description", "initScript", null, "1", false, null, null, true, "jenkins", null, false, null, false,
-				false, 5, 0, true, "jenkins", true, "network1_id,network2_id", "security_group1,security_group2");
+				false, 5, 0, true, "jenkins", true, "network1_id,network2_id", "security_group1,security_group2", false);
 
 		List<JCloudsSlaveTemplate> templates = new ArrayList<JCloudsSlaveTemplate>();
 		templates.add(originalTemplate);


### PR DESCRIPTION
Using BitVise SSH Server (e.g. not using Cygwin+sshd) would fail to copy the `slave.jar` onto Windows instance due to the destination location `/tmp'. This change allows the indication of a Windows image when adding/configuring a Cloud Instance Template to properly copy and execute the slave.jar on Windows instance using Command Prompt (or PowerShell).