### PR TITLE
Fix admin credentials

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -252,7 +252,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         if (!Strings.isNullOrEmpty(vmUser)) {
             return vmUser;
         }
-        final StandardUsernameCredentials u = CredentialsHelper.getCredentialsById(credentialsId);
+        final StandardUsernameCredentials u = CredentialsHelper.getCredentialsById(adminCredentialsId);
         if (null == u || null == Util.fixEmptyAndTrim(u.getUsername())) {
             return "root";
         } else {


### PR DESCRIPTION
The credentials to get the admin user are pulled from normal credentials, not admin.   This fix resolves it.
