### PR TITLE
Add setProfiles method to BlobStorePublisher DescriptorImpl

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStorePublisher.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStorePublisher.java
@@ -240,10 +240,14 @@ public class BlobStorePublisher extends Recorder implements Describable<Publishe
 
         @Override
         public boolean configure(StaplerRequest req, net.sf.json.JSONObject json) throws FormException {
-            profiles.replaceBy(req.bindParametersToList(BlobStoreProfile.class, "jcblobstore."));
+            setProfiles(req.bindParametersToList(BlobStoreProfile.class, "jcblobstore."));
             save();
             return true;
         }
+
+        public void setProfiles(List<BlobStoreProfile> newProfiles) {
+            profiles.replaceBy(newProfiles);
+	}
 
         public BlobStoreProfile[] getProfiles() {
             return profiles.toArray(new BlobStoreProfile[0]);


### PR DESCRIPTION
I want to manage the configured blobstore profiles with a Groovy script. This lets me do something like this:

```groovy
// Get credentials from somewhere and build a list of profiles...
BlobStorePublisher.DESCRIPTOR.setProfiles(profiles)
BlobStorePublisher.DESCRIPTOR.save()
```

Maybe there's a better way to do that, but I couldn't find one.