### PR TITLE
JENKINS-41078 support latest config-file-provider plugin (2.15.4)

### DIFF
--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>2.15.4</version>
+      <version>2.15.5</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/jclouds-plugin/pom.xml
+++ b/jclouds-plugin/pom.xml
@@ -65,7 +65,7 @@ limitations under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>config-file-provider</artifactId>
-      <version>2.13</version>
+      <version>2.15.4</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/AbstractJCloudsConfigProviderImpl.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/AbstractJCloudsConfigProviderImpl.java
@@ -29,4 +29,13 @@ public abstract class AbstractJCloudsConfigProviderImpl extends AbstractConfigPr
 
     public AbstractJCloudsConfigProviderImpl() {
     }
+
+    /*
+     * jclouds plugin currently does not support configuration files on folder scope
+     * - all configurations stored with config-file-proider are on global scope!
+     */
+    @Override
+    public boolean supportsFolder() {
+        return false;
+    }
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/ConfigHelper.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/ConfigHelper.java
@@ -17,6 +17,7 @@ package jenkins.plugins.jclouds.config;
 
 import hudson.util.ListBoxModel;
 
+import jenkins.model.Jenkins;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.jenkinsci.lib.configprovider.ConfigProvider;
@@ -49,6 +50,7 @@ import javax.mail.internet.MimeMessage;
 import javax.mail.internet.MimeMultipart;
 
 import jenkins.plugins.jclouds.compute.UserData;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
 
 public class ConfigHelper {
 
@@ -59,9 +61,11 @@ public class ConfigHelper {
 
     @NonNull
     public static String getConfig(@Nullable final String id) {
-        final Config cfg = Config.getByIdOrNull(id);
-        if (null != cfg && null != cfg.content) {
-            return cfg.content;
+        if(id != null) {
+            final Config cfg = ConfigFiles.getByIdOrNull(Jenkins.getActiveInstance(), id);
+            if (null != cfg && null != cfg.content) {
+                return cfg.content;
+            }
         }
         return "";
     }
@@ -100,7 +104,7 @@ public class ConfigHelper {
     private static List<Config> getConfigs(@NonNull final List<String> configIds) {
         List<Config> ret = new ArrayList<>();
         for (final String id : configIds) {
-            final Config cfg = Config.getByIdOrNull(id);
+            final Config cfg = ConfigFiles.getByIdOrNull(Jenkins.getActiveInstance(), id);
             if (null != cfg) {
                 ret.add(cfg);
             }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataBoothook.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataBoothook.java
@@ -16,6 +16,8 @@
 package jenkins.plugins.jclouds.config;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -30,8 +32,13 @@ public class UserDataBoothook extends Config {
         super(id, name, comment, content);
     }
 
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataBoothookProvider.class);
+    }
+
     @Extension(ordinal = 70)
-    @ConfigSuitableFor(target=UserData.class)
+    @ConfigSuitableFor(target = UserData.class)
     public static class UserDataBoothookProvider extends AbstractJCloudsConfigProviderImpl {
 
         private static final String SIGNATURE = "^#cloud-boothook[\\r\\n]+";
@@ -63,14 +70,22 @@ public class UserDataBoothook extends Config {
         }
 
         @Override
-        public Config newConfig() {
+        public UserDataBoothook newConfig() {
             String id = getProviderId() + "." + System.currentTimeMillis();
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+            return new UserDataBoothook(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
         }
 
         @Override
-        public Config newConfig(final String id) {
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT, getProviderId());
+        public UserDataBoothook newConfig(final String id) {
+            return new UserDataBoothook(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+        }
+
+        /**
+         * used for data migration only (config-file-provider prior 1.15)
+         */
+        @Override
+        public UserDataBoothook convert(Config config) {
+            return new UserDataBoothook(config.id, config.name, config.comment, config.content);
         }
     }
 

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataInclude.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataInclude.java
@@ -16,6 +16,8 @@
 package jenkins.plugins.jclouds.config;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -29,8 +31,13 @@ public class UserDataInclude extends Config {
         super(id, name, comment, content);
     }
 
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataIncludeProvider.class);
+    }
+
     @Extension(ordinal = 70)
-    @ConfigSuitableFor(target=UserData.class)
+    @ConfigSuitableFor(target = UserData.class)
     public static class UserDataIncludeProvider extends AbstractJCloudsConfigProviderImpl {
 
         private static final String SIGNATURE = "^#include[\\r\\n]+";
@@ -67,14 +74,22 @@ public class UserDataInclude extends Config {
         }
 
         @Override
-        public Config newConfig() {
+        public UserDataInclude newConfig() {
             String id = getProviderId() + "." + System.currentTimeMillis();
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+            return new UserDataInclude(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
         }
 
         @Override
-        public Config newConfig(final String id) {
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT, getProviderId());
+        public UserDataInclude newConfig(final String id) {
+            return new UserDataInclude(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+        }
+
+        /**
+         * used for data migration only (config-file-provider prior 1.15)
+         */
+        @Override
+        public UserDataInclude convert(Config config) {
+            return new UserDataInclude(config.id, config.name, config.comment, config.content);
         }
     }
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataIncludeOnce.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataIncludeOnce.java
@@ -16,6 +16,8 @@
 package jenkins.plugins.jclouds.config;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -29,8 +31,13 @@ public class UserDataIncludeOnce extends Config {
         super(id, name, comment, content);
     }
 
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataIncludeOnceProvider.class);
+    }
+
     @Extension(ordinal = 70)
-    @ConfigSuitableFor(target=UserData.class)
+    @ConfigSuitableFor(target = UserData.class)
     public static class UserDataIncludeOnceProvider extends AbstractJCloudsConfigProviderImpl {
 
         private static final String SIGNATURE = "^#include-once[\\r\\n]+";
@@ -67,14 +74,22 @@ public class UserDataIncludeOnce extends Config {
         }
 
         @Override
-        public Config newConfig() {
+        public UserDataIncludeOnce newConfig() {
             String id = getProviderId() + "." + System.currentTimeMillis();
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+            return new UserDataIncludeOnce(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
         }
 
         @Override
-        public Config newConfig(final String id) {
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT, getProviderId());
+        public UserDataIncludeOnce newConfig(final String id) {
+            return new UserDataIncludeOnce(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+        }
+
+        /**
+         * used for data migration only (config-file-provider prior 1.15)
+         */
+        @Override
+        public UserDataIncludeOnce convert(Config config) {
+            return new UserDataIncludeOnce(config.id, config.name, config.comment, config.content);
         }
     }
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataPartHandler.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataPartHandler.java
@@ -16,11 +16,12 @@
 package jenkins.plugins.jclouds.config;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
+import jenkins.plugins.jclouds.compute.UserData;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
-
-import jenkins.plugins.jclouds.compute.UserData;
 
 public class UserDataPartHandler extends Config {
 
@@ -29,8 +30,13 @@ public class UserDataPartHandler extends Config {
         super(id, name, comment, content);
     }
 
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataPartHandlerProvider.class);
+    }
+
     @Extension(ordinal = 70)
-    @ConfigSuitableFor(target=UserData.class)
+    @ConfigSuitableFor(target = UserData.class)
     public static class UserDataPartHandlerProvider extends AbstractJCloudsConfigProviderImpl {
 
         private static final String SIGNATURE = "^#part-handler[\\r\\n]+";
@@ -80,14 +86,22 @@ public class UserDataPartHandler extends Config {
         }
 
         @Override
-        public Config newConfig() {
+        public UserDataPartHandler newConfig() {
             String id = getProviderId() + "." + System.currentTimeMillis();
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+            return new UserDataPartHandler(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
         }
 
         @Override
-        public Config newConfig(final String id) {
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT, getProviderId());
+        public UserDataPartHandler newConfig(final String id) {
+            return new UserDataPartHandler(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+        }
+
+        /**
+         * used for data migration only (config-file-provider prior 1.15)
+         */
+        @Override
+        public UserDataPartHandler convert(Config config) {
+            return new UserDataPartHandler(config.id, config.name, config.comment, config.content);
         }
     }
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataScript.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataScript.java
@@ -16,6 +16,8 @@
 package jenkins.plugins.jclouds.config;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -29,8 +31,13 @@ public class UserDataScript extends Config {
         super(id, name, comment, content);
     }
 
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataScriptProvider.class);
+    }
+
     @Extension(ordinal = 70)
-    @ConfigSuitableFor(target=UserData.class)
+    @ConfigSuitableFor(target = UserData.class)
     public static class UserDataScriptProvider extends AbstractJCloudsConfigProviderImpl {
 
         private static final String SIGNATURE = "^#!";
@@ -62,14 +69,22 @@ public class UserDataScript extends Config {
         }
 
         @Override
-        public Config newConfig() {
+        public UserDataScript newConfig() {
             String id = getProviderId() + "." + System.currentTimeMillis();
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+            return new UserDataScript(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
         }
 
         @Override
-        public Config newConfig(final String id) {
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT, getProviderId());
+        public UserDataScript newConfig(final String id) {
+            return new UserDataScript(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+        }
+
+        /**
+         * used for data migration only (config-file-provider prior 1.15)
+         */
+        @Override
+        public UserDataScript convert(Config config) {
+            return new UserDataScript(config.id, config.name, config.comment, config.content);
         }
     }
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataUpstart.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataUpstart.java
@@ -16,6 +16,8 @@
 package jenkins.plugins.jclouds.config;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -30,8 +32,13 @@ public class UserDataUpstart extends Config {
         super(id, name, comment, content);
     }
 
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataUpstartProvider.class);
+    }
+
     @Extension(ordinal = 70)
-    @ConfigSuitableFor(target=UserData.class)
+    @ConfigSuitableFor(target = UserData.class)
     public static class UserDataUpstartProvider extends AbstractJCloudsConfigProviderImpl {
 
         private static final String SIGNATURE = "^#upstart-job[\\r\\n]+";
@@ -63,14 +70,22 @@ public class UserDataUpstart extends Config {
         }
 
         @Override
-        public Config newConfig() {
+        public UserDataUpstart newConfig() {
             String id = getProviderId() + "." + System.currentTimeMillis();
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+            return new UserDataUpstart(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
         }
 
         @Override
-        public Config newConfig(final String id) {
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT, getProviderId());
+        public UserDataUpstart newConfig(final String id) {
+            return new UserDataUpstart(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+        }
+
+        /**
+         * used for data migration only (config-file-provider prior 1.15)
+         */
+        @Override
+        public UserDataUpstart convert(Config config) {
+            return new UserDataUpstart(config.id, config.name, config.comment, config.content);
         }
     }
 }

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataYaml.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/config/UserDataYaml.java
@@ -16,6 +16,8 @@
 package jenkins.plugins.jclouds.config;
 
 import hudson.Extension;
+import jenkins.model.Jenkins;
+import org.jenkinsci.lib.configprovider.ConfigProvider;
 import org.jenkinsci.lib.configprovider.model.Config;
 import org.jenkinsci.lib.configprovider.model.ContentType;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -29,8 +31,13 @@ public class UserDataYaml extends Config {
         super(id, name, comment, content);
     }
 
+    @Override
+    public ConfigProvider getDescriptor() {
+        return Jenkins.getActiveInstance().getDescriptorByType(UserDataYamlProvider.class);
+    }
+
     @Extension(ordinal = 70)
-    @ConfigSuitableFor(target=UserData.class)
+    @ConfigSuitableFor(target = UserData.class)
     public static class UserDataYamlProvider extends AbstractJCloudsConfigProviderImpl {
 
         private static final String SIGNATURE = "^#cloud-config[\\r\\n]+";
@@ -64,12 +71,20 @@ public class UserDataYaml extends Config {
         @Override
         public Config newConfig() {
             String id = getProviderId() + "." + System.currentTimeMillis();
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+            return new UserDataYaml(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
         }
 
         @Override
         public Config newConfig(final String id) {
-            return new Config(id, DEFAULT_NAME, "", DEFAULT_CONTENT, getProviderId());
+            return new UserDataYaml(id, DEFAULT_NAME, "", DEFAULT_CONTENT);
+        }
+
+        /**
+         * used for data migration only (config-file-provider prior 1.15)
+         */
+        @Override
+        public UserDataYaml convert(Config config) {
+            return new UserDataYaml(config.id, config.name, config.comment, config.content);
         }
     }
 }

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/MigrationTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/MigrationTest.java
@@ -16,6 +16,7 @@
 package jenkins.plugins.jclouds.compute;
 
 
+import org.apache.commons.io.FileUtils;
 import org.junit.Test;
 import org.junit.Rule;
 
@@ -30,6 +31,7 @@ import jenkins.model.Jenkins;
 import hudson.FilePath;
 
 import java.io.File;
+import java.util.Collection;
 import java.util.Scanner;
 
 public class MigrationTest {
@@ -43,7 +45,7 @@ public class MigrationTest {
             File target = new File(targetPath);
             File src = Jenkins.getInstance().root;
             target.mkdirs();
-            new FilePath(src).copyRecursiveTo("**/*",new FilePath(target));
+            new FilePath(src).copyRecursiveTo("**/*", new FilePath(target));
         }
     }
 
@@ -80,15 +82,17 @@ public class MigrationTest {
         saveMigrationResult("/tmp/upgradeFromTwoDotEightDotOneDashOne");
 
         File jhome = Jenkins.getInstance().root;
+
         File f = new File(jhome, "credentials.xml");
         assertTrue("File credentials.xml exists in JENKINS_HOME", f.exists());
         assertEquals("File size of credentials.xml", 7246, f.length());
-        f = new File(jhome, "jenkins.plugins.jclouds.config.UserDataScript.xml");
-        assertTrue("File jenkins.plugins.jclouds.config.UserDataScript.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataScript.xml", 667, f.length());
-        f = new File(jhome, "jenkins.plugins.jclouds.config.UserDataYaml.xml");
-        assertTrue("File jenkins.plugins.jclouds.config.UserDataYaml.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataYaml.xml", 667, f.length());
+        f = new File(jhome, "org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml");
+        String globalConfigFileContent = FileUtils.readFileToString(f);
+        assertTrue("File org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml exists in JENKINS_HOME", f.exists());
+        assertTrue("jenkins.plugins.jclouds.config.UserDataYaml must be found in global config", globalConfigFileContent.contains("jenkins.plugins.jclouds.config.UserDataYaml"));
+        assertTrue("jenkins.plugins.jclouds.config.UserDataScript must be found in global config", globalConfigFileContent.contains("jenkins.plugins.jclouds.config.UserDataScript"));
+        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataScript.xml", 843, f.length());
+
         f = new File(jhome, "config.xml");
         assertTrue("File config.xml exists in JENKINS_HOME", f.exists());
         assertEquals("File size of config.xml", 3720, f.length());
@@ -101,11 +105,14 @@ public class MigrationTest {
         saveMigrationResult("/tmp/upgradeFromTwoDotNine");
 
         File jhome = Jenkins.getInstance().root;
-        File f = new File(jhome, "jenkins.plugins.jclouds.config.UserDataScript.xml");
-        assertTrue("File jenkins.plugins.jclouds.config.UserDataScript.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataScript.xml", 667, f.length());
-        f = new File(jhome, "jenkins.plugins.jclouds.config.UserDataYaml.xml");
-        assertTrue("File jenkins.plugins.jclouds.config.UserDataYaml.xml exists in JENKINS_HOME", f.exists());
+
+        File f = new File(jhome, "org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml");
+        String globalConfigFileContent = FileUtils.readFileToString(f);
+        assertTrue("File org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml exists in JENKINS_HOME", f.exists());
+        assertTrue("jenkins.plugins.jclouds.config.UserDataYaml must be found in global config", globalConfigFileContent.contains("jenkins.plugins.jclouds.config.UserDataYaml"));
+        assertTrue("jenkins.plugins.jclouds.config.UserDataScript must be found in global config", globalConfigFileContent.contains("jenkins.plugins.jclouds.config.UserDataScript"));
+        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataScript.xml", 843, f.length());
+
         f = new File(jhome, "config.xml");
         assertTrue("File config.xml exists in JENKINS_HOME", f.exists());
         assertEquals("File size of config.xml", 3750, f.length());
@@ -118,16 +125,17 @@ public class MigrationTest {
         saveMigrationResult("/tmp/upgradeFromTwoDotTen");
 
         File jhome = Jenkins.getInstance().root;
-        File f = new File(jhome, "jenkins.plugins.jclouds.config.UserDataInclude.xml");
-        assertTrue("File jenkins.plugins.jclouds.config.UserDataInclude.xml exists in JENKINS_HOME", f.exists());
+
+        File f = new File(jhome, "org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml");
+        assertTrue("File org.jenkinsci.plugins.configfiles.GlobalConfigFiles.xml exists in JENKINS_HOME", f.exists());
+        String globalConfigFileContent = FileUtils.readFileToString(f);
+        System.out.println(globalConfigFileContent);
+        assertTrue("jenkins.plugins.jclouds.config.UserDataInclude must be found in global config", globalConfigFileContent.contains("jenkins.plugins.jclouds.config.UserDataInclude"));
+        assertTrue("jenkins.plugins.jclouds.config.UserDataScript must be found in global config", globalConfigFileContent.contains("jenkins.plugins.jclouds.config.UserDataScript"));
+        assertTrue("jenkins.plugins.jclouds.config.UserDataYaml must be found in global config", globalConfigFileContent.contains("jenkins.plugins.jclouds.config.UserDataYaml"));
         // file size checks are reliable, because the generated uuids in there have a constant lenght
-        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataInclude.xml", 1785, f.length());
-        f = new File(jhome, "jenkins.plugins.jclouds.config.UserDataScript.xml");
-        assertTrue("File jenkins.plugins.jclouds.config.UserDataScript.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataScript.xml", 678, f.length());
-        f = new File(jhome, "jenkins.plugins.jclouds.config.UserDataYaml.xml");
-        assertTrue("File jenkins.plugins.jclouds.config.UserDataYaml.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataYaml.xml", 1685, f.length());
+        assertEquals("File size of jenkins.plugins.jclouds.config.UserDataScript.xml", 2742, f.length());
+
         f = new File(jhome, "config.xml");
         assertTrue("File config.xml exists in JENKINS_HOME", f.exists());
         assertEquals("File size of config.xml", 17495, f.length());

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/UserDataConverterTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/UserDataConverterTest.java
@@ -17,9 +17,13 @@ package jenkins.plugins.jclouds.compute;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.configfiles.ConfigFiles;
+import org.jenkinsci.plugins.configfiles.GlobalConfigFiles;
 import org.junit.Test;
 import org.junit.Rule;
 import static org.junit.Assert.assertEquals;
@@ -47,7 +51,7 @@ public class UserDataConverterTest {
     public void testMigrationBoothook() {
         String data = "#cloud-boothook\nfoo bar baz";
         UserData ud = UserData.createFromData(data, "test1.cfg");
-        Config c = Config.getById(ud.fileId);
+        final Config c = ConfigFiles.getByIdOrNull(j.getInstance(), ud.fileId);
         ConfigProvider p = c.getProvider();
         assertTrue("Provider is an instance of UserDataBoothookProvider", p instanceof UserDataBoothookProvider);
     }
@@ -56,7 +60,7 @@ public class UserDataConverterTest {
     public void testMigrationInclude() {
         String data = "#include\nfoo bar baz";
         UserData ud = UserData.createFromData(data, "test1.cfg");
-        Config c = Config.getById(ud.fileId);
+        final Config c = ConfigFiles.getByIdOrNull(j.getInstance(), ud.fileId);
         ConfigProvider p = c.getProvider();
         assertTrue("Provider is an instance of UserDataIncludeProvider", p instanceof UserDataIncludeProvider);
     }
@@ -65,7 +69,7 @@ public class UserDataConverterTest {
     public void testMigrationIncludeOnce() {
         String data = "#include-once\nfoo bar baz";
         UserData ud = UserData.createFromData(data, "test1.cfg");
-        Config c = Config.getById(ud.fileId);
+        final Config c = ConfigFiles.getByIdOrNull(j.getInstance(), ud.fileId);
         ConfigProvider p = c.getProvider();
         assertTrue("Provider is an instance of UserDataIncludeOnceProvider", p instanceof UserDataIncludeOnceProvider);
     }
@@ -74,7 +78,7 @@ public class UserDataConverterTest {
     public void testMigrationScript() {
         String data = "#!/bin/sh\nfoo bar baz";
         UserData ud = UserData.createFromData(data, "test1.cfg");
-        Config c = Config.getById(ud.fileId);
+        final Config c = ConfigFiles.getByIdOrNull(j.getInstance(), ud.fileId);
         ConfigProvider p = c.getProvider();
         assertTrue("Provider is an instance of UserDataScriptProvider", p instanceof UserDataScriptProvider);
     }
@@ -83,7 +87,7 @@ public class UserDataConverterTest {
     public void testMigrationUpstart() {
         String data = "#upstart-job\nfoo bar baz";
         UserData ud = UserData.createFromData(data, "test1.cfg");
-        Config c = Config.getById(ud.fileId);
+        final Config c = ConfigFiles.getByIdOrNull(j.getInstance(), ud.fileId);
         ConfigProvider p = c.getProvider();
         assertTrue("Provider is an instance of UserDataUpstartProvider", p instanceof UserDataUpstartProvider);
     }
@@ -92,7 +96,7 @@ public class UserDataConverterTest {
     public void testMigrationYaml() {
         String data = "#cloud-config\napt_upgrade: true";
         UserData ud = UserData.createFromData(data, "test1.cfg");
-        Config c = Config.getById(ud.fileId);
+        final Config c = ConfigFiles.getByIdOrNull(j.getInstance(), ud.fileId);
         ConfigProvider p = c.getProvider();
         assertTrue("Provider is an instance of UserDataYamlProvider", p instanceof UserDataYamlProvider);
     }


### PR DESCRIPTION
Update to support latest config-file-provider version.

Although the latest config-file-provider now supports configuration files on folder level, this PR updates the jcloud plugin to support on global scope only - which is the same as it was before this update.

To support folders, one would have to update all occurrences of `final Config cfg = ConfigFiles.getByIdOrNull(Jenkins.getActiveInstance(), id);` to use the correct scope object, e.g. the current build instead of `Jenkins.getActiveInstance()`.
e.g. in `jenkins.plugins.jclouds.config.ConfigHelper#getConfig`

Note: I'm not familiar with the usage of the jclouds plugin and therefore I was not able to test this in a real scenario. 

cc @felfert 