### PR TITLE
Added the Packet provider

### DIFF
--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -57,6 +57,11 @@ limitations under the License.
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>packet</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-allblobstore</artifactId>
       <version>${jclouds.version}</version>


### PR DESCRIPTION
The Packet provider has been in labs for a while and it is proven to be very stable. There is actually a PR to promote it to the main repo in the next jclouds major release: https://github.com/jclouds/jclouds/pull/1103.

This PR adds the Packet provider, so we can start using it without waiting for the next jclouds major, since there is no official date for it yet.