### PR TITLE
Added google and b2 blob store providers

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfile.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfile.java
@@ -293,7 +293,7 @@ public class BlobStoreProfile  extends AbstractDescribableImpl<BlobStoreProfile>
                 .includeAs(ACL.SYSTEM, context, StandardUsernameCredentials.class).includeCurrentValue(currentValue);
         }
 
-        private ImmutableSortedSet<String> getAllProviders() {
+        ImmutableSortedSet<String> getAllProviders() {
             // correct the classloader so that extensions can be found
             Thread.currentThread().setContextClassLoader(Apis.class.getClassLoader());
             // TODO: apis need endpoints, providers don't; do something smarter

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfileTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfileTest.java
@@ -1,0 +1,39 @@
+package jenkins.plugins.jclouds.blobstore;
+
+import jenkins.plugins.jclouds.blobstore.BlobStoreProfile;
+import org.junit.Test;
+import shaded.com.google.common.collect.ImmutableSortedSet;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.assertTrue;
+
+
+public class BlobStoreProfileTest {
+
+    private static String[] ALL_BLOBSTORE_PROVIDERS = new String[] {
+        "atmos",
+        "aws-s3",
+        "azureblob",
+        "b2",
+        "filesystem",
+        "google-cloud-storage",
+        "openstack-swift",
+        "rackspace-cloudfiles",
+        "rackspace-cloudfiles-uk",
+        "rackspace-cloudfiles-us",
+        "s3",
+        "transient"
+    };
+
+    @Test
+    public void testGetAllProviders() {
+        BlobStoreProfile.DescriptorImpl desc = new BlobStoreProfile.DescriptorImpl();
+        ImmutableSortedSet<String> providers = desc.getAllProviders();
+
+        //System.out.println(providers.toString());
+
+        assertTrue(providers.size() == ALL_BLOBSTORE_PROVIDERS.length); //make sure we are aware of provider count changes
+        assertTrue(providers.containsAll(Arrays.asList(ALL_BLOBSTORE_PROVIDERS)));
+  }
+}

--- a/jclouds-shaded/pom.xml
+++ b/jclouds-shaded/pom.xml
@@ -67,6 +67,16 @@ limitations under the License.
       <version>${jclouds.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>b2</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>google-cloud-storage</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.jclouds.driver</groupId>
       <artifactId>jclouds-enterprise</artifactId>
       <version>${jclouds.version}</version>


### PR DESCRIPTION
Google Cloud Storage is not yet part of jclouds-allblobstore but will be
from version 2.1.0 onwards.

Also added test to ensure we have all the cloud storage providers we want
and are aware of newly added or accidentally removed storage providers.