### PR TITLE
Use networks setting for AWS EC2 subnetId

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -450,8 +450,13 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             TemplateOptions options = template.getOptions();
 
             if (!isNullOrEmpty(networks)) {
-                LOGGER.info("Setting networks to " + networks);
-                options.networks(csvToArray(networks));
+                if (networks.startsWith("subnet-") && options instanceof AWSEC2TemplateOptions) {
+                    LOGGER.info("Setting AWS EC2 subnetId to " + networks);
+                    options.as(AWSEC2TemplateOptions.class).subnetId(networks);
+                } else {
+                    LOGGER.info("Setting networks to " + networks);
+                    options.networks(csvToArray(networks));
+                }
             }
 
             if (!isNullOrEmpty(securityGroups)) {


### PR DESCRIPTION
According to [documentation](https://jclouds.apache.org/guides/aws-ec2/) this should fix https://issues.jenkins-ci.org/browse/JENKINS-47301.

I see that JClouds doesn't use `networks` option for anything in AWS EC2.
So, it is OK to reuse existing option in plugin.
However, this should probably be fixed in JClouds.