### PR TITLE
[WIP] Add preemptible option for GCE

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -510,7 +510,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                 // Always use our own credentials and let creation fail
                 // if no keys are provided.
                 options.as(GoogleComputeEngineTemplateOptions.class).autoCreateKeyPair(false);
-                options.preemptible(isPreemptible);
+                options.as(GoogleComputeEngineTemplateOptions.class).preemptible(isPreemptible);
             }
 
             if (assignPublicIp) {

--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -172,6 +172,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     public final String securityGroups;
     public final Mode mode;
     public final boolean useConfigDrive;
+    public final boolean isPreemptible;
     private final String credentialsId;
     private final String adminCredentialsId;
     private final List<UserData> userDataEntries;
@@ -216,7 +217,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             final boolean assignFloatingIp, final boolean waitPhoneHome, final int waitPhoneHomeTimeout,
             final String keyPairName, final boolean assignPublicIp, final String networks,
             final String securityGroups, final String credentialsId, final String adminCredentialsId,
-            final String mode, final boolean useConfigDrive, final List<UserData> userDataEntries,
+            final String mode, final boolean useConfigDrive, final boolean isPreemptible, final List<UserData> userDataEntries,
             final String preferredAddress, final boolean useJnlp) {
 
         this.name = Util.fixEmptyAndTrim(name);
@@ -252,6 +253,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         this.adminCredentialsId = Util.fixEmptyAndTrim(adminCredentialsId);
         this.mode = Mode.valueOf(Util.fixNull(mode));
         this.useConfigDrive = useConfigDrive;
+        this.isPreemptible = isPreemptible;
         this.userDataEntries = userDataEntries;
         this.preferredAddress = preferredAddress;
         this.useJnlp = useJnlp;
@@ -508,6 +510,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                 // Always use our own credentials and let creation fail
                 // if no keys are provided.
                 options.as(GoogleComputeEngineTemplateOptions.class).autoCreateKeyPair(false);
+                options.preemptible(isPreemptible);
             }
 
             if (assignPublicIp) {

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -148,6 +148,11 @@ limitations under the License.
         <f:entry title="${%Allow Sudo}" field="allowSudo">
           <f:checkbox />
         </f:entry>
+        
+        <f:entry title="${%Is preemptible (GCP only)}" field="isPreemptible">
+          <f:checkbox />
+        </f:entry>
+        
         <f:entry title="${%Install Private Key}" field="installPrivateKey">
           <f:checkbox />
         </f:entry>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -35,7 +35,7 @@ limitations under the License.
         <f:number clazz="positive-number" min="1" step="1" default="2"/>
       </f:entry>
     </f:block>
-    
+
     <f:block>
       <b>${%Hardware Options}</b>
       <f:radioBlock inline="true" name="jclouds.useHardwareId" value="true"
@@ -46,13 +46,13 @@ limitations under the License.
         <f:validateButton title="${%Check Hardware Id}" progress="${%Checking...}" method="validateHardwareId"
                             with="providerName,cloudCredentialsId,endPointUrl,hardwareId"/>
       </f:radioBlock>
-      
+
       <f:radioBlock inline="true" name="jclouds.useHardwareId" value="false"
                     title="${%Specify RAM and Cores}" checked="${instance.hardwareId == ''}">
         <f:entry title="${%Min. RAM (MB)}" field="ram">
           <f:number clazz="positive-number" min="1" step="1" default="512"/>
         </f:entry>
-        
+
         <f:entry title="${%Min. No.of Cores}" field="cores">
           <f:number clazz="positive-number" min="1.0" step="1.0" default="1.0"/>
         </f:entry>
@@ -66,7 +66,7 @@ limitations under the License.
         <f:entry title="Image Id" field="imageId">
           <f:textbox />
         </f:entry>
-        
+
         <f:validateButton title="${%Check Image Id}" progress="${%Checking...}" method="validateImageId"
                           with="providerName,cloudCredentialsId,endPointUrl,imageId"/>
       </f:radioBlock>
@@ -86,7 +86,7 @@ limitations under the License.
         <f:entry title="${%OS Family}" field="osFamily">
           <f:textbox/>
         </f:entry>
-        
+
         <f:entry title="${%OS Version}" field="osVersion">
           <f:textbox/>
         </f:entry>
@@ -109,11 +109,11 @@ limitations under the License.
             <f:number clazz="number" min="-1" step="1"/>
           </f:entry>
         </f:optionalBlock>
-      
+
         <f:entry title="${%Delay before spooling up (ms)}" field="spoolDelayMs">
           <f:number clazz="number" min="0" step="1" default="0"/>
         </f:entry>
-      
+
         <f:entry title="${%Init Script}" help="${descriptor.getHelpFile('initScriptId')}">
           <div style="margin-right:200px;">
             <div style="float:left;width:100%;"><f:select field="initScriptId" clazz="jclouds"/></div>
@@ -144,30 +144,30 @@ limitations under the License.
                  field="preExistingJenkinsUser">
           <f:checkbox />
         </f:entry>
-      
+
         <f:entry title="${%Allow Sudo}" field="allowSudo">
           <f:checkbox />
         </f:entry>
-        
-        <f:entry title="${%Is preemptible (GCP only)}" field="isPreemptible">
+
+        <f:entry title="${%Is preemptible}" field="isPreemptible">
           <f:checkbox />
         </f:entry>
-        
+
         <f:entry title="${%Install Private Key}" field="installPrivateKey">
           <f:checkbox />
         </f:entry>
         <f:entry title="Remote FS Root" field="fsRoot">
           <f:textbox default="/jenkins" />
         </f:entry>
-      
+
         <f:entry title="${%Admin credentials}" field="adminCredentialsId">
             <c:select/>
         </f:entry>
-      
+
         <f:entry title="${%Custom JVM Options}" field="jvmOptions">
           <f:textbox />
         </f:entry>
-      
+
         <f:entry title="${%Stop on Terminate}" field="stopOnTerminate">
           <f:checkbox />
         </f:entry>
@@ -211,7 +211,7 @@ limitations under the License.
         <f:repeatableDeleteButton value="${%Delete template}" />
       </div>
     </f:entry>
-    
+
   </table>
   <st:once>
     <script type="text/javascript" src="${rootURL}/plugin/jclouds-jenkins/jclouds.js"/>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -35,7 +35,7 @@ limitations under the License.
         <f:number clazz="positive-number" min="1" step="1" default="2"/>
       </f:entry>
     </f:block>
-
+    
     <f:block>
       <b>${%Hardware Options}</b>
       <f:radioBlock inline="true" name="jclouds.useHardwareId" value="true"
@@ -46,13 +46,13 @@ limitations under the License.
         <f:validateButton title="${%Check Hardware Id}" progress="${%Checking...}" method="validateHardwareId"
                             with="providerName,cloudCredentialsId,endPointUrl,hardwareId"/>
       </f:radioBlock>
-
+      
       <f:radioBlock inline="true" name="jclouds.useHardwareId" value="false"
                     title="${%Specify RAM and Cores}" checked="${instance.hardwareId == ''}">
         <f:entry title="${%Min. RAM (MB)}" field="ram">
           <f:number clazz="positive-number" min="1" step="1" default="512"/>
         </f:entry>
-
+        
         <f:entry title="${%Min. No.of Cores}" field="cores">
           <f:number clazz="positive-number" min="1.0" step="1.0" default="1.0"/>
         </f:entry>
@@ -66,7 +66,7 @@ limitations under the License.
         <f:entry title="Image Id" field="imageId">
           <f:textbox />
         </f:entry>
-
+        
         <f:validateButton title="${%Check Image Id}" progress="${%Checking...}" method="validateImageId"
                           with="providerName,cloudCredentialsId,endPointUrl,imageId"/>
       </f:radioBlock>
@@ -86,7 +86,7 @@ limitations under the License.
         <f:entry title="${%OS Family}" field="osFamily">
           <f:textbox/>
         </f:entry>
-
+        
         <f:entry title="${%OS Version}" field="osVersion">
           <f:textbox/>
         </f:entry>
@@ -109,11 +109,11 @@ limitations under the License.
             <f:number clazz="number" min="-1" step="1"/>
           </f:entry>
         </f:optionalBlock>
-
+      
         <f:entry title="${%Delay before spooling up (ms)}" field="spoolDelayMs">
           <f:number clazz="number" min="0" step="1" default="0"/>
         </f:entry>
-
+      
         <f:entry title="${%Init Script}" help="${descriptor.getHelpFile('initScriptId')}">
           <div style="margin-right:200px;">
             <div style="float:left;width:100%;"><f:select field="initScriptId" clazz="jclouds"/></div>
@@ -144,30 +144,28 @@ limitations under the License.
                  field="preExistingJenkinsUser">
           <f:checkbox />
         </f:entry>
-
+      
         <f:entry title="${%Allow Sudo}" field="allowSudo">
           <f:checkbox />
         </f:entry>
-
         <f:entry title="${%Is preemptible}" field="isPreemptible">
           <f:checkbox />
         </f:entry>
-
         <f:entry title="${%Install Private Key}" field="installPrivateKey">
           <f:checkbox />
         </f:entry>
         <f:entry title="Remote FS Root" field="fsRoot">
           <f:textbox default="/jenkins" />
         </f:entry>
-
+      
         <f:entry title="${%Admin credentials}" field="adminCredentialsId">
             <c:select/>
         </f:entry>
-
+      
         <f:entry title="${%Custom JVM Options}" field="jvmOptions">
           <f:textbox />
         </f:entry>
-
+      
         <f:entry title="${%Stop on Terminate}" field="stopOnTerminate">
           <f:checkbox />
         </f:entry>
@@ -211,9 +209,10 @@ limitations under the License.
         <f:repeatableDeleteButton value="${%Delete template}" />
       </div>
     </f:entry>
-
+    
   </table>
   <st:once>
     <script type="text/javascript" src="${rootURL}/plugin/jclouds-jenkins/jclouds.js"/>
   </st:once>
 </j:jelly>
+

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -26,7 +26,8 @@ public class JCloudsSlaveTemplateTest {
                 null /* keyPairName */, true /* assignPublicIp */, "network1_id,network2_id",
                 "security_group1,security_group2", null /* credentialsId */,
                 null /* adminCredentialsId */, "NORMAL" /* mode */, true /* useConfigDrive */,
-                null /* configDataIds */, "192.168.1.0/24" /* preferredAddress */, false /* useJnlp */ );
+                false /* preemptible */, null /* configDataIds */, "192.168.1.0/24" /* preferredAddress */,
+                false /* useJnlp */ );
 
         final List<JCloudsSlaveTemplate> templates = new ArrayList<>();
         templates.add(beforeTemplate);
@@ -44,7 +45,7 @@ public class JCloudsSlaveTemplateTest {
         j.assertEqualBeans(beforeCloud, afterCloud,
                 "profile,providerName,endPointUrl,trustAll,groupPrefix");
         j.assertEqualBeans(beforeTemplate, afterTemplate,
-                "name,cores,ram,osFamily,osVersion,labelString,description,numExecutors,stopOnTerminate,mode,useConfigDrive,preferredAddress,useJnlp");
+                "name,cores,ram,osFamily,osVersion,labelString,description,numExecutors,stopOnTerminate,mode,useConfigDrive,preemptible,preferredAddress,useJnlp");
     }
 
 }


### PR DESCRIPTION
Hi everyone, 

Since 2015, `jcloud` supports preemptible options on Google Container Engine: [JCLOUD-1001](https://issues.apache.org/jira/browse/JCLOUDS-1001). 

As requested by users @ [JENKINS-44601](https://issues.jenkins-ci.org/browse/JENKINS-44601), I added the possibility to create instances on GCE with `preemptible` options. 

