### PR TITLE
Add Preemptible option for GCP 

### DIFF
--- a/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/jclouds-plugin/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -172,6 +172,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
     public final String securityGroups;
     public final Mode mode;
     public final boolean useConfigDrive;
+    public final boolean isPreemptible;
     private final String credentialsId;
     private final String adminCredentialsId;
     private final List<UserData> userDataEntries;
@@ -216,7 +217,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
             final boolean assignFloatingIp, final boolean waitPhoneHome, final int waitPhoneHomeTimeout,
             final String keyPairName, final boolean assignPublicIp, final String networks,
             final String securityGroups, final String credentialsId, final String adminCredentialsId,
-            final String mode, final boolean useConfigDrive, final List<UserData> userDataEntries,
+            final String mode, final boolean useConfigDrive, final boolean isPreemptible, final List<UserData> userDataEntries,
             final String preferredAddress, final boolean useJnlp) {
 
         this.name = Util.fixEmptyAndTrim(name);
@@ -252,6 +253,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         this.adminCredentialsId = Util.fixEmptyAndTrim(adminCredentialsId);
         this.mode = Mode.valueOf(Util.fixNull(mode));
         this.useConfigDrive = useConfigDrive;
+        this.isPreemptible = isPreemptible;
         this.userDataEntries = userDataEntries;
         this.preferredAddress = preferredAddress;
         this.useJnlp = useJnlp;
@@ -508,6 +510,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
                 // Always use our own credentials and let creation fail
                 // if no keys are provided.
                 options.as(GoogleComputeEngineTemplateOptions.class).autoCreateKeyPair(false);
+                options.as(GoogleComputeEngineTemplateOptions.class).preemptible(isPreemptible);
             }
 
             if (assignPublicIp) {

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -148,6 +148,9 @@ limitations under the License.
         <f:entry title="${%Allow Sudo}" field="allowSudo">
           <f:checkbox />
         </f:entry>
+        <f:entry title="${%Is preemptible}" field="isPreemptible">
+          <f:checkbox />
+        </f:entry>
         <f:entry title="${%Install Private Key}" field="installPrivateKey">
           <f:checkbox />
         </f:entry>
@@ -212,3 +215,4 @@ limitations under the License.
     <script type="text/javascript" src="${rootURL}/plugin/jclouds-jenkins/jclouds.js"/>
   </st:once>
 </j:jelly>
+

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -45,7 +45,7 @@ public class JCloudsSlaveTemplateTest {
         j.assertEqualBeans(beforeCloud, afterCloud,
                 "profile,providerName,endPointUrl,trustAll,groupPrefix");
         j.assertEqualBeans(beforeTemplate, afterTemplate,
-                "name,cores,ram,osFamily,osVersion,labelString,description,numExecutors,stopOnTerminate,mode,useConfigDrive,preemptible,preferredAddress,useJnlp");
+                "name,cores,ram,osFamily,osVersion,labelString,description,numExecutors,stopOnTerminate,mode,useConfigDrive,isPreemptible,preferredAddress,useJnlp");
     }
 
 }

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplateTest.java
@@ -26,7 +26,8 @@ public class JCloudsSlaveTemplateTest {
                 null /* keyPairName */, true /* assignPublicIp */, "network1_id,network2_id",
                 "security_group1,security_group2", null /* credentialsId */,
                 null /* adminCredentialsId */, "NORMAL" /* mode */, true /* useConfigDrive */,
-                null /* configDataIds */, "192.168.1.0/24" /* preferredAddress */, false /* useJnlp */ );
+                false /* preemptible */, null /* configDataIds */, "192.168.1.0/24" /* preferredAddress */,
+                false /* useJnlp */ );
 
         final List<JCloudsSlaveTemplate> templates = new ArrayList<>();
         templates.add(beforeTemplate);
@@ -44,7 +45,7 @@ public class JCloudsSlaveTemplateTest {
         j.assertEqualBeans(beforeCloud, afterCloud,
                 "profile,providerName,endPointUrl,trustAll,groupPrefix");
         j.assertEqualBeans(beforeTemplate, afterTemplate,
-                "name,cores,ram,osFamily,osVersion,labelString,description,numExecutors,stopOnTerminate,mode,useConfigDrive,preferredAddress,useJnlp");
+                "name,cores,ram,osFamily,osVersion,labelString,description,numExecutors,stopOnTerminate,mode,useConfigDrive,preemptible,preferredAddress,useJnlp");
     }
 
 }

--- a/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/MigrationTest.java
+++ b/jclouds-plugin/src/test/java/jenkins/plugins/jclouds/compute/MigrationTest.java
@@ -95,7 +95,7 @@ public class MigrationTest {
 
         f = new File(jhome, "config.xml");
         assertTrue("File config.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of config.xml", 3755, f.length());
+        assertEquals("File size of config.xml", 3802, f.length());
         checkTags(f);
     }
 
@@ -115,7 +115,7 @@ public class MigrationTest {
 
         f = new File(jhome, "config.xml");
         assertTrue("File config.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of config.xml", 3785, f.length());
+        assertEquals("File size of config.xml", 3832, f.length());
         checkTags(f);
     }
 
@@ -138,7 +138,7 @@ public class MigrationTest {
 
         f = new File(jhome, "config.xml");
         assertTrue("File config.xml exists in JENKINS_HOME", f.exists());
-        assertEquals("File size of config.xml", 17705, f.length());
+        assertEquals("File size of config.xml", 17987, f.length());
         checkTags(f);
     }
 }


### PR DESCRIPTION
Since 2015, `jclouds` supports preemptible options on Google Container Engine: [JCLOUDS-1001](https://issues.apache.org/jira/browse/JCLOUDS-1001). 

As requested by users @ [JENKINS-44601](https://issues.jenkins-ci.org/browse/JENKINS-44601), I added the possibility to create instances on GCE with `preemptible` options. 

It has been tested on our Jenkins and VMs have been populated with preemptible option. 
