### PR TITLE
[JENKINS-55787] Switch labels from entry to checkbox

### DIFF
--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStoreProfile/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStoreProfile/config.jelly
@@ -29,8 +29,8 @@ limitations under the License.
     <f:entry title="${%Credentials}" field="credentialsId">
       <c:select/>
     </f:entry>
-    <f:entry title="${%Relax security}" field="trustAll">
-      <f:checkbox/>
+    <f:entry field="trustAll">
+      <f:checkbox title="${%Relax security}"/>
     </f:entry>
     <f:validateButton title="${%Test Connection}" progress="${%Testing...}" method="testConnection" with="providerName,credentialsId,endPointUrl,trustAll"/>
     <f:entry title="">

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/InstancesToRun/config.jelly
@@ -39,8 +39,8 @@ limitations under the License.
     <f:number clazz="positive-number" min="1" step="1" default="1"/>
   </f:entry>
   
-  <f:entry title="${%Stop on Terminate}" field="suspendOrTerminate">
-    <f:checkbox />
+  <f:entry field="suspendOrTerminate">
+    <f:checkbox title="${%Stop on Terminate}"/>
   </f:entry>
   
   <f:entry>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/config.jelly
@@ -34,8 +34,8 @@ limitations under the License.
   <f:entry title="${%Credentials}" field="cloudCredentialsId">
     <c:select/>
   </f:entry>
-  <f:entry title="${%Relax security}" field="trustAll">
-    <f:checkbox/>
+  <f:entry field="trustAll">
+    <f:checkbox title="${%Relax security}"/>
   </f:entry>
   <f:entry title="${%Cloud RSA key}" field="cloudGlobalKeyId">
     <c:select/>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -140,16 +140,15 @@ limitations under the License.
             <c:select/>
         </f:entry>
 
-        <f:entry title="${%Use Pre-existing Jenkins User}"
-                 field="preExistingJenkinsUser">
-          <f:checkbox />
+        <f:entry field="preExistingJenkinsUser">
+          <f:checkbox title="${%Use Pre-existing Jenkins User}"/>
         </f:entry>
       
-        <f:entry title="${%Allow Sudo}" field="allowSudo">
-          <f:checkbox />
+        <f:entry field="allowSudo">
+          <f:checkbox title="${%Allow Sudo}"/>
         </f:entry>
-        <f:entry title="${%Install Private Key}" field="installPrivateKey">
-          <f:checkbox />
+        <f:entry field="installPrivateKey">
+          <f:checkbox title="${%Install Private Key}"/>
         </f:entry>
         <f:entry title="Remote FS Root" field="fsRoot">
           <f:textbox default="/jenkins" />
@@ -163,8 +162,8 @@ limitations under the License.
           <f:textbox />
         </f:entry>
       
-        <f:entry title="${%Stop on Terminate}" field="stopOnTerminate">
-          <f:checkbox />
+        <f:entry field="stopOnTerminate">
+          <f:checkbox title="${%Stop on Terminate}"/>
         </f:entry>
 
         <f:entry title="${%Networks}" field="networks">
@@ -175,8 +174,8 @@ limitations under the License.
           <f:textbox />
         </f:entry>
 
-        <f:entry title="${%Wait for slave to phone home}" field="waitPhoneHome">
-          <f:checkbox />
+        <f:entry field="waitPhoneHome">
+          <f:checkbox title="${%Wait for slave to phone home}"/>
         </f:entry>
 
         <f:entry title="${%Phone home timeout}" field="waitPhoneHomeTimeout">
@@ -186,17 +185,17 @@ limitations under the License.
         <f:entry title="${%Key Pair Name}" field="keyPairName">
           <f:textbox />
         </f:entry>
-        <f:entry title="${%Use config drive}" field="useConfigDrive">
-          <f:checkbox />
+        <f:entry field="useConfigDrive">
+          <f:checkbox title="${%Use config drive}"/>
         </f:entry>
-        <f:entry title="${%Assign Public IP}" field="assignPublicIp">
-          <f:checkbox default="true"/>
+        <f:entry field="assignPublicIp">
+          <f:checkbox title="${%Assign Public IP}" default="true"/>
         </f:entry>
         <f:entry title="${%Preferred Address}" field="preferredAddress">
           <f:textbox />
         </f:entry>
-        <f:entry title="${%Use JNLP}" field="useJnlp">
-          <f:checkbox />
+        <f:entry field="useJnlp">
+          <f:checkbox title="${%Use JNLP}"/>
         </f:entry>
       </f:block>
     </f:advanced>


### PR DESCRIPTION
[JENKINS-55787](https://issues.jenkins-ci.org/browse/JENKINS-55787)

Basically checkboxes should have labels, splitting the labels away from their checkboxes is poor UX, poor accessibility. This change brings the layout more inline with how normal settings UIs lay out checkboxes.

Without this change, using current table ui:
![image](https://user-images.githubusercontent.com/2119212/64215156-7032ef00-ce81-11e9-9ec5-730e886b69cc.png)

With this change, using current table ui:
![image](https://user-images.githubusercontent.com/2119212/64215222-b8eaa800-ce81-11e9-815c-59a89bbde0dc.png)

Without this change, using the table-less ui:

![image](https://user-images.githubusercontent.com/2119212/64214956-87251180-ce80-11e9-95ad-130f7f31ce54.png)

With this change, using the table-less ui:

![image](https://user-images.githubusercontent.com/2119212/64215088-1f22fb00-ce81-11e9-95ee-0ee02200d000.png)
