### PR TITLE
JENKINS-64537 Compatibility with Jenkins core >=2.264

### DIFF
--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStoreProfile/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/blobstore/BlobStoreProfile/config.jelly
@@ -15,8 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <table width="100%" class="pane">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:jc="/lib/jclouds">
+  <jc:blockWrapper>
     <f:entry title="${%Profile name}" field="profileName">
       <f:textbox/>
     </f:entry>
@@ -48,5 +48,5 @@ limitations under the License.
           with="providerName,credentialsId,endPointUrl,locationId"/>
       </f:block>
     </f:advanced>
-  </table>
+  </jc:blockWrapper>
 </j:jelly>

--- a/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
+++ b/jclouds-plugin/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate/config.jelly
@@ -15,10 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials">
-  <table width="100%" class="pane">
-
-
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:c="/lib/credentials" xmlns:jc="/lib/jclouds">
+  <jc:blockWrapper>
     <f:block>
       <b>${%General Configuration}</b>
       <f:entry title="${%Name}" field="name">
@@ -212,7 +210,7 @@ limitations under the License.
       </div>
     </f:entry>
     
-  </table>
+  </jc:blockWrapper>
   <st:once>
     <script type="text/javascript" src="${rootURL}/plugin/jclouds-jenkins/jclouds.js"/>
   </st:once>

--- a/jclouds-plugin/src/main/resources/lib/jclouds/blockWrapper.jelly
+++ b/jclouds-plugin/src/main/resources/lib/jclouds/blockWrapper.jelly
@@ -1,0 +1,16 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:d="jelly:define">
+    <!-- TODO remove and switch to div after baseline is 2.264 or newer -->
+    <j:choose>
+        <j:when test="${divBasedFormLayout}">
+            <div class="pane">
+                <d:invokeBody/>
+            </div>
+        </j:when>
+        <j:otherwise>
+            <table style="width:100%" class="pane">
+                <d:invokeBody/>
+            </table>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>


### PR DESCRIPTION
Easier to test with https://github.com/jenkinsci/jclouds-plugin/pull/142

Following https://www.jenkins.io/doc/developer/views/table-to-div-migration/

See https://www.jenkins.io/blog/2020/11/10/major-changes-in-weekly-releases/

I'm not sure if this is causing an issue but I'm working through all the plugins that appear with tabular markup in https://issues.jenkins.io/browse/JENKINS-64341