### PR TITLE
Stop using deprecated `Util#join`

### DIFF
--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper.java
@@ -148,7 +148,7 @@ public class JCloudsBuildWrapper extends BuildWrapper {
                 @Override
                 public void buildEnvVars(Map<String, String> env) {
                     List<String> ips = getInstanceIPs(runningNodes, listener.getLogger());
-                    env.put("JCLOUDS_IPS", Util.join(ips, ","));
+                    env.put("JCLOUDS_IPS", String.join(",", ips));
                 }
 
                 @Override


### PR DESCRIPTION
This method was deprecated in jenkinsci/jenkins#5467, so migrate away from it in favor of native Java Platform functionality.