### PR TITLE
Stop shading Guava/Guice

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.3</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,12 @@ limitations under the License.
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.15</version>
+    <version>4.37</version>
+    <relativePath />
   </parent>
 
   <artifactId>jclouds-jenkins</artifactId>
-  <version>2.26-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Jenkins JClouds plugin</name>
   <description>Allows Jenkins to build using Cloud Servers via JClouds</description>
@@ -36,6 +37,8 @@ limitations under the License.
   </licenses>
 
   <properties>
+    <revision>2.26</revision>
+    <changelist>-SNAPSHOT</changelist>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <test.jenkins.compute.provider>FIXME_PROVIDER</test.jenkins.compute.provider>
     <test.jenkins.compute.endpoint />
@@ -56,8 +59,9 @@ limitations under the License.
     <jclouds.version>2.4.0</jclouds.version>
     <!-- Depend on latest Jenkins 2.x LTS
          See README of https://github.com/jenkinsci/plugin-pom/ -->
-    <jenkins.version>2.263.1</jenkins.version>
+    <jenkins.version>2.332</jenkins.version>
     <java.level>8</java.level>
+    <gitHubRepo>jenkinsci/jclouds-plugin</gitHubRepo>
   </properties>
 
   <developers>
@@ -102,24 +106,19 @@ limitations under the License.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.263.x</artifactId>
-        <version>20</version>
+        <artifactId>bom-2.332.x</artifactId>
+        <version>1181.v04b_21d4b_0d6c</version>
         <scope>import</scope>
         <type>pom</type>
-      </dependency>
-      <dependency>
-        <groupId>net.i2p.crypto</groupId>
-        <artifactId>eddsa</artifactId>
-        <version>0.3.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/jclouds-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/jclouds-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/jclouds-plugin</url>
-    <tag>HEAD</tag>
+    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
+    <tag>${scmTag}</tag>
   </scm>
 
   <repositories>
@@ -142,11 +141,6 @@ limitations under the License.
       <artifactId>trilead-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.jenkins.plugins</groupId>
-      <artifactId>jaxb</artifactId>
-      <version>2.3.0.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.felfert</groupId>
       <artifactId>cidrutils</artifactId>
       <version>1.4</version>
@@ -159,7 +153,6 @@ limitations under the License.
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>bouncycastle-api</artifactId>
-      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -186,12 +179,113 @@ limitations under the License.
     <dependency>
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
-      <version>2.8.5</version>
+      <version>2.8.9</version>
     </dependency>
     <dependency>
-      <groupId>com.github.felfert</groupId>
-      <artifactId>jclouds-shaded</artifactId>
-      <version>2.3.0</version>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>javax-activation-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>javax-mail-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${jclouds.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.inject</groupId>
+          <artifactId>guice</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-allcompute</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>oneandone</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.labs</groupId>
+      <artifactId>profitbricks-rest</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-allblobstore</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-enterprise</artifactId>
+      <version>${jclouds.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcprov-ext-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-sshj</artifactId>
+      <version>${jclouds.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bouncycastle</groupId>
+          <artifactId>bcpkix-jdk15on</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-scriptbuilder</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds.driver</groupId>
+      <artifactId>jclouds-jsch</artifactId>
+      <version>${jclouds.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-core</artifactId>
+      <version>${jclouds.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.annotation</groupId>
+          <artifactId>javax.annotation-api</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-compute</artifactId>
+      <version>${jclouds.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jclouds</groupId>
+      <artifactId>jclouds-blobstore</artifactId>
+      <version>${jclouds.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@ limitations under the License.
     <jclouds.version>2.4.0</jclouds.version>
     <!-- Depend on latest Jenkins 2.x LTS
          See README of https://github.com/jenkinsci/plugin-pom/ -->
-    <jenkins.version>2.332</jenkins.version>
+    <jenkins.version>2.332.1</jenkins.version>
     <java.level>8</java.level>
     <gitHubRepo>jenkinsci/jclouds-plugin</gitHubRepo>
   </properties>
@@ -107,7 +107,7 @@ limitations under the License.
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.332.x</artifactId>
-        <version>1181.v04b_21d4b_0d6c</version>
+        <version>1195.v33041c1f1b_b_2</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfile.java
+++ b/src/main/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfile.java
@@ -24,11 +24,11 @@ import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
-import shaded.com.google.common.collect.ImmutableSet;
-import shaded.com.google.common.collect.ImmutableSet.Builder;
-import shaded.com.google.common.collect.ImmutableSortedSet;
-import shaded.com.google.common.collect.Iterables;
-import shaded.com.google.inject.Module;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
+import com.google.inject.Module;
 
 import hudson.Extension;
 import hudson.FilePath;

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsBuildWrapper.java
@@ -51,12 +51,12 @@ import org.kohsuke.stapler.DataBoundConstructor;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
-import shaded.com.google.common.cache.CacheBuilder;
-import shaded.com.google.common.cache.CacheLoader;
-import shaded.com.google.common.cache.LoadingCache;
-import shaded.com.google.common.collect.ImmutableList;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import shaded.com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.util.concurrent.MoreExecutors;
 
 public class JCloudsBuildWrapper extends SimpleBuildWrapper {

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCleanupThread.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCleanupThread.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AsyncPeriodicWork;
 import hudson.model.Computer;
@@ -57,6 +58,7 @@ public final class JCloudsCleanupThread extends AsyncPeriodicWork {
         return Level.FINE;
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     @Override
     protected void execute(TaskListener listener) {
         final ImmutableList.Builder<ListenableFuture<?>> deletedNodesBuilder = ImmutableList.<ListenableFuture<?>>builder();

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsCloud.java
@@ -15,7 +15,7 @@
  */
 package jenkins.plugins.jclouds.compute;
 
-import javax.annotation.Nonnull;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.servlet.ServletException;
 import java.io.Closeable;
 import java.io.IOException;
@@ -31,7 +31,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Logger;
 
-import shaded.com.google.inject.Module;
+import com.google.inject.Module;
 import hudson.Extension;
 import hudson.Util;
 import hudson.init.Initializer;
@@ -77,11 +77,11 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 import org.kohsuke.stapler.verb.POST;
 
-import shaded.com.google.common.base.Strings;
-import shaded.com.google.common.collect.ImmutableSet;
-import shaded.com.google.common.collect.ImmutableSet.Builder;
-import shaded.com.google.common.collect.ImmutableSortedSet;
-import shaded.com.google.common.collect.Iterables;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Iterables;
 
 import com.cloudbees.plugins.credentials.common.StandardUsernameCredentials;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
@@ -587,7 +587,7 @@ public class JCloudsCloud extends Cloud {
          * Human readable name of this kind of configurable object.
          * @return The human readable name of this object. 
          */
-        @Nonnull
+        @NonNull
         @Override
         public String getDisplayName() {
             return "Cloud (JClouds)";

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsComputer.java
@@ -26,8 +26,8 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.jenkinsci.plugins.cloudstats.TrackedItem;

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlave.java
@@ -50,8 +50,8 @@ import org.jenkinsci.plugins.cloudstats.ProvisioningActivity;
 import org.jenkinsci.plugins.cloudstats.TrackedItem;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsSlaveTemplate.java
@@ -15,8 +15,8 @@
  */
 package jenkins.plugins.jclouds.compute;
 
-import static shaded.com.google.common.collect.Iterables.getOnlyElement;
-import static shaded.com.google.common.collect.Lists.newArrayList;
+import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.google.common.collect.Lists.newArrayList;
 import static org.jclouds.scriptbuilder.domain.Statements.newStatementList;
 
 import java.io.IOException;
@@ -38,8 +38,8 @@ import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import org.apache.commons.codec.binary.Base64;
@@ -93,10 +93,10 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
 import au.com.bytecode.opencsv.CSVReader;
-import shaded.com.google.common.base.Optional;
-import shaded.com.google.common.base.Predicate;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import com.google.common.base.Supplier;
-import shaded.com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMap;
 
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsMatcher;
@@ -352,6 +352,7 @@ public class JCloudsSlaveTemplate implements Describable<JCloudsSlaveTemplate>, 
         return labelSet;
     }
 
+    @SuppressFBWarnings("DMI_RANDOM_USED_ONLY_ONCE")
     private String generateNonce() {
         Random r = new Random(java.lang.System.currentTimeMillis());
         StringBuilder ret = new StringBuilder();

--- a/src/main/java/jenkins/plugins/jclouds/compute/JCloudsStartupHandler.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/JCloudsStartupHandler.java
@@ -30,8 +30,8 @@ import java.nio.file.DirectoryStream;
 import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
 
-import shaded.com.google.common.base.Predicate;
-import shaded.com.google.common.collect.Multimap;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Multimap;
 
 import hudson.Extension;
 import hudson.model.listeners.ItemListener;

--- a/src/main/java/jenkins/plugins/jclouds/compute/UserData.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/UserData.java
@@ -19,10 +19,11 @@ import java.lang.reflect.Field;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
@@ -79,6 +80,7 @@ public final class UserData extends AbstractDescribableImpl<UserData> {
         return new UserData(c.id);
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private static Field getConfigField(String name) {
         Field field = findField(Config.class, name);
         field.setAccessible(true);

--- a/src/main/java/jenkins/plugins/jclouds/compute/internal/JCloudsNodeMetadata.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/internal/JCloudsNodeMetadata.java
@@ -24,7 +24,7 @@ import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.compute.domain.OperatingSystem;
 import org.jclouds.domain.Location;
 import org.jclouds.domain.LoginCredentials;
-import org.jclouds.javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 import org.jclouds.compute.domain.internal.NodeMetadataImpl;
 

--- a/src/main/java/jenkins/plugins/jclouds/compute/internal/ProvisionPlannedInstancesAndDestroyAllOnError.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/internal/ProvisionPlannedInstancesAndDestroyAllOnError.java
@@ -18,9 +18,10 @@ package jenkins.plugins.jclouds.compute.internal;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jclouds.logging.Logger;
 
-import shaded.com.google.common.base.Function;
+import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
@@ -38,6 +39,7 @@ public class ProvisionPlannedInstancesAndDestroyAllOnError implements Function<I
         this.terminateNodes = terminateNodes;
     }
 
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public Iterable<RunningNode> apply(Iterable<NodePlan> nodePlans) {
         final ImmutableList.Builder<RunningNode> cloudTemplateNodeBuilder = ImmutableList.<RunningNode>builder();
 

--- a/src/main/java/jenkins/plugins/jclouds/compute/internal/TerminateNodes.java
+++ b/src/main/java/jenkins/plugins/jclouds/compute/internal/TerminateNodes.java
@@ -26,13 +26,13 @@ import org.jclouds.compute.ComputeService;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.logging.Logger;
 
-import shaded.com.google.common.base.Function;
-import shaded.com.google.common.base.Predicate;
-import shaded.com.google.common.cache.LoadingCache;
-import shaded.com.google.common.collect.ImmutableMultimap;
-import shaded.com.google.common.collect.Multimap;
-import shaded.com.google.common.collect.ArrayListMultimap;
-import shaded.com.google.common.collect.ImmutableMultimap.Builder;
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMultimap.Builder;
 
 public class TerminateNodes implements Function<Iterable<RunningNode>, Void> {
 

--- a/src/main/java/jenkins/plugins/jclouds/config/ConfigDataSource.java
+++ b/src/main/java/jenkins/plugins/jclouds/config/ConfigDataSource.java
@@ -33,7 +33,7 @@ import jenkins.plugins.jclouds.internal.ReplaceHelper;
 
 import org.jenkinsci.lib.configprovider.ConfigProvider;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**

--- a/src/main/java/jenkins/plugins/jclouds/config/ConfigHelper.java
+++ b/src/main/java/jenkins/plugins/jclouds/config/ConfigHelper.java
@@ -39,8 +39,8 @@ import java.util.zip.GZIPOutputStream;
 import javax.activation.DataHandler;
 import javax.activation.DataSource;
 
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 import javax.mail.BodyPart;

--- a/src/main/java/jenkins/plugins/jclouds/internal/ReplaceHelper.java
+++ b/src/main/java/jenkins/plugins/jclouds/internal/ReplaceHelper.java
@@ -18,7 +18,7 @@ package jenkins.plugins.jclouds.internal;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**

--- a/src/main/resources/META-INF/hudson.remoting.ClassFilter
+++ b/src/main/resources/META-INF/hudson.remoting.ClassFilter
@@ -1,2 +1,2 @@
-shaded.com.google.common.collect.EmptyImmutableListMultimap
-shaded.com.google.common.collect.ImmutableListMultimap
+com.google.common.collect.EmptyImmutableListMultimap
+com.google.common.collect.ImmutableListMultimap

--- a/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfileTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreProfileTest.java
@@ -1,6 +1,6 @@
 package jenkins.plugins.jclouds.blobstore;
 
-import shaded.com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableSortedSet;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreTestFixture.java
+++ b/src/test/java/jenkins/plugins/jclouds/blobstore/BlobStoreTestFixture.java
@@ -1,7 +1,5 @@
 package jenkins.plugins.jclouds.blobstore;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 
 import org.jclouds.apis.BaseViewLiveTest;
@@ -9,11 +7,11 @@ import org.jclouds.blobstore.BlobStore;
 import org.jclouds.blobstore.BlobStoreContext;
 import org.jclouds.util.Maps2;
 
-import shaded.com.google.common.base.Function;
-import shaded.com.google.common.base.Predicates;
-import shaded.com.google.common.base.Strings;
-import shaded.com.google.common.collect.Maps;
-import shaded.com.google.common.reflect.TypeToken;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.common.reflect.TypeToken;
 
 import jenkins.plugins.jclouds.internal.CredentialsHelper;
 

--- a/src/test/java/jenkins/plugins/jclouds/compute/ComputeTestFixture.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/ComputeTestFixture.java
@@ -1,7 +1,5 @@
 package jenkins.plugins.jclouds.compute;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Map;
 
 import org.jclouds.compute.ComputeService;
@@ -9,11 +7,11 @@ import org.jclouds.compute.internal.BaseComputeServiceContextLiveTest;
 import org.jclouds.sshj.config.SshjSshClientModule;
 import org.jclouds.util.Maps2;
 
-import shaded.com.google.common.base.Function;
-import shaded.com.google.common.base.Predicates;
-import shaded.com.google.common.base.Strings;
-import shaded.com.google.common.collect.Maps;
-import shaded.com.google.inject.Module;
+import com.google.common.base.Function;
+import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.inject.Module;
 
 import jenkins.plugins.jclouds.internal.CredentialsHelper;
 

--- a/src/test/java/jenkins/plugins/jclouds/compute/JCloudsProfileTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/JCloudsProfileTest.java
@@ -1,6 +1,6 @@
 package jenkins.plugins.jclouds.compute;
 
-import shaded.com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableSortedSet;
 import org.junit.Test;
 
 import java.util.Arrays;

--- a/src/test/java/jenkins/plugins/jclouds/compute/internal/TerminateNodesTest.java
+++ b/src/test/java/jenkins/plugins/jclouds/compute/internal/TerminateNodesTest.java
@@ -18,15 +18,15 @@ import org.jclouds.compute.RunNodesException;
 import org.jclouds.compute.domain.NodeMetadata;
 import org.jclouds.logging.Logger;
 
-import shaded.com.google.common.base.Function;
-import shaded.com.google.common.base.Functions;
-import shaded.com.google.common.cache.CacheBuilder;
-import shaded.com.google.common.cache.CacheLoader;
-import shaded.com.google.common.cache.LoadingCache;
-import shaded.com.google.common.collect.ImmutableList;
-import shaded.com.google.common.collect.ImmutableMap;
-import shaded.com.google.common.collect.Iterables;
-import shaded.com.google.common.collect.Lists;
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 import org.jvnet.hudson.test.JenkinsRule;
 


### PR DESCRIPTION
**Untested** PR to switch this plugin from using shaded/bundled copies of Guava/Guice to the (newly upgraded) versions of Guava and Guice in Jenkins core 2.321 and later. Note that this raises the minimum Jenkins version to a weekly (2.321). It also means we stop bundling Guava and Guice in this plugin. This should simplify maintenance by making everything less complicated.