### PR TITLE
Use `Cloud#getUrl` in /provision URL

### DIFF
--- a/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/computerSet.jelly
+++ b/src/main/resources/jenkins/plugins/jclouds/compute/JCloudsCloud/computerSet.jelly
@@ -23,7 +23,7 @@ limitations under the License.
             <td/>
             <td colspan="${monitors.size()+2}">
 
-                <f:form action="${rootURL}/cloud/${it.name}/provision" method="post" name="provision">
+                <f:form action="${rootURL}/${it.url}/provision" method="post" name="provision">
                     <input type="submit" class="jclouds-provision-button" value="${%Provision via JClouds} - ${it.name}"/>
                     <select name="name">
                         <j:forEach var="t" items="${it.templates}">


### PR DESCRIPTION
Follow up of https://github.com/jenkinsci/jenkins/pull/7573.

This has no effect on older versions of Jenkins. On newer versions of Jenkins this prevents a bug that I've briefly described in the PR linked above.