### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,8 @@ limitations under the License.
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.401.x</artifactId>
-        <version>2675.v1515e14da_7a_6</version>
+        <artifactId>bom-2.414.x</artifactId>
+        <version>2705.vf5c48c31285b_</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>

--- a/src/main/java/jenkins/plugins/jclouds/modules/JenkinsBouncyCastleCrypto.java
+++ b/src/main/java/jenkins/plugins/jclouds/modules/JenkinsBouncyCastleCrypto.java
@@ -7,7 +7,7 @@ import java.security.cert.CertificateException;
 
 import javax.crypto.Cipher;
 import javax.crypto.NoSuchPaddingException;
-import javax.inject.Singleton;
+import jakarta.inject.Singleton;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jclouds.crypto.Crypto;


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.