### PR TITLE
Fixed NumberFormatException in digitalocean2 provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,19 @@ limitations under the License.
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-allcompute</artifactId>
       <version>${jclouds.version}</version>
+      <exclusions>
+        <!-- exclude broken digitalocean2 ... -->
+        <exclusion>
+          <groupId>org.apache.jclouds.provider</groupId>
+          <artifactId>digitalocean2</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <!-- ... and use our backported fix instead -->
+    <dependency>
+      <groupId>com.github.felfert</groupId>
+      <artifactId>digitalocean2-fixed</artifactId>
+      <version>2.5.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.jclouds</groupId>


### PR DESCRIPTION
Replaced org.apache.jclouds.provider:digitalocean2 v2.5.0 by com.github.felfert:digitalocean2-fixed v2.5.2
This fixes a NumberFormatException when creating a droplet.
This is a backported fix of [this PR](https://github.com/apache/jclouds/pull/216) in upstream.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
